### PR TITLE
Feat/favorite lots

### DIFF
--- a/apps/mobile/__tests__/AzureAuth.test.ts
+++ b/apps/mobile/__tests__/AzureAuth.test.ts
@@ -56,7 +56,13 @@ describe('AzureAuth', () => {
       accessTokenExpirationDate: new Date(Date.now() + 3600000).toISOString(),
       tokenType: 'Bearer',
       userId: 'test-user-id',
-      scopes: ['openid', 'profile', 'email', 'offline_access'],
+      scopes: [
+        'openid',
+        'profile',
+        'email',
+        'offline_access',
+        `api://9aea0ab1-4502-4868-a31b-0a8f333cec9c/access_as_user`
+      ],
     };
 
     it('should successfully login and return auth result', async () => {
@@ -67,7 +73,13 @@ describe('AzureAuth', () => {
       expect(authorize).toHaveBeenCalledWith(
         expect.objectContaining({
           clientId: '9aea0ab1-4502-4868-a31b-0a8f333cec9c',
-          scopes: ['openid', 'profile', 'email', 'offline_access'],
+          scopes: [
+            'openid',
+            'profile',
+            'email',
+            'offline_access',
+            `api://9aea0ab1-4502-4868-a31b-0a8f333cec9c/access_as_user`
+          ],
           usePKCE: true,
           useNonce: true,
         }),

--- a/apps/mobile/__tests__/AzureAuth.test.ts
+++ b/apps/mobile/__tests__/AzureAuth.test.ts
@@ -55,6 +55,7 @@ describe('AzureAuth', () => {
       refreshToken: 'mock-refresh-token',
       accessTokenExpirationDate: new Date(Date.now() + 3600000).toISOString(),
       tokenType: 'Bearer',
+      userId: 'test-user-id',
       scopes: ['openid', 'profile', 'email', 'offline_access'],
     };
 
@@ -166,6 +167,7 @@ describe('AzureAuth', () => {
         refreshToken: 'test-refresh-token',
         accessTokenExpirationDate: new Date().toISOString(),
         tokenType: 'Bearer',
+        userId: 'test-user-id',
       };
 
       (Keychain.setGenericPassword as jest.Mock).mockResolvedValue(true);
@@ -206,6 +208,7 @@ describe('AzureAuth', () => {
         // Token expires in 1 hour
         accessTokenExpirationDate: new Date(Date.now() + 3600000).toISOString(),
         tokenType: 'Bearer',
+        userId: 'test-user-id',
       };
 
       (Keychain.getGenericPassword as jest.Mock).mockResolvedValue({
@@ -225,6 +228,7 @@ describe('AzureAuth', () => {
         // Token expired 1 hour ago
         accessTokenExpirationDate: new Date(Date.now() - 3600000).toISOString(),
         tokenType: 'Bearer',
+        userId: 'test-user-id',
       };
 
       const refreshedResult = {
@@ -233,6 +237,7 @@ describe('AzureAuth', () => {
         refreshToken: 'new-refresh-token',
         accessTokenExpirationDate: new Date(Date.now() + 3600000).toISOString(),
         tokenType: 'Bearer',
+        userId: 'test-user-id',
       };
 
       (Keychain.getGenericPassword as jest.Mock).mockResolvedValue({
@@ -262,6 +267,7 @@ describe('AzureAuth', () => {
         refreshToken: 'invalid-refresh-token',
         accessTokenExpirationDate: new Date(Date.now() - 3600000).toISOString(),
         tokenType: 'Bearer',
+        userId: 'test-user-id',
       };
 
       (Keychain.getGenericPassword as jest.Mock).mockResolvedValue({
@@ -283,6 +289,7 @@ describe('AzureAuth', () => {
         refreshToken: undefined,
         accessTokenExpirationDate: new Date(Date.now() - 3600000).toISOString(),
         tokenType: 'Bearer',
+        userId: 'test-user-id',
       };
 
       (Keychain.getGenericPassword as jest.Mock).mockResolvedValue({

--- a/apps/mobile/__tests__/favorites.service.test.ts
+++ b/apps/mobile/__tests__/favorites.service.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Favorite Service Tests
+ */
+import favoritesApi from '../src/services/api/favorites';
+import { apiService } from '../src/services/api/base';
+
+jest.mock('../src/services/api/base', () => {
+  return {
+    apiService: {
+      get: jest.fn(),
+      post: jest.fn(),
+      delete: jest.fn(),
+    },
+    ApiError: class MockApiError {
+      status: number;
+      message: string;
+      constructor(status: number, message: string) {
+        this.status = status;
+        this.message = message;
+      }
+    }
+  };
+});
+
+const mockApiService = apiService as jest.Mocked<typeof apiService>;
+const mockRefreshSession = jest.fn();
+
+describe('FavoritesService', () => {
+  const userId = 'test-user-id';
+  const accessToken = 'mock-access-token';
+  const lotId = 'G1';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getAllFavorites', () => {
+    it('fetches all favorites for a user', async () => {
+      const mockData = { success: true, data: ['G1', 'G3', 'G4'] };
+      mockApiService.get.mockResolvedValueOnce(mockData);
+
+      const result = await favoritesApi.getAllFavorites(userId, accessToken, mockRefreshSession);
+
+      expect(mockApiService.get).toHaveBeenCalledWith(
+        expect.stringContaining(`/users/${encodeURIComponent(userId)}/favorites`),
+        expect.objectContaining({
+          headers: { 'Authorization': `Bearer ${accessToken}` }
+        })
+      );
+      expect(result).toEqual(['G1', 'G3', 'G4']);
+    });
+  });
+
+  describe('addFavorite', () => {
+    it('successfully adds a favorite lot', async () => {
+      const mockResponse = { success: true, data: undefined };
+      mockApiService.post.mockResolvedValueOnce(mockResponse);
+
+      await favoritesApi.addFavorite(userId, accessToken, lotId, mockRefreshSession);
+
+      expect(mockApiService.post).toHaveBeenCalledWith(
+        expect.stringContaining(`/favorites/${lotId}`),
+        {},
+        expect.objectContaining({
+          headers: { 'Authorization': `Bearer ${accessToken}` }
+        })
+      );
+    });
+  });
+
+  describe('removeFavorite', () => {
+    it('successfully removes a favorite lot', async () => {
+      const mockResponse = { success: true, data: undefined };
+      mockApiService.delete.mockResolvedValueOnce(mockResponse);
+
+      await favoritesApi.removeFavorite(userId, accessToken, lotId, mockRefreshSession);
+
+      expect(mockApiService.delete).toHaveBeenCalledWith(
+        expect.stringContaining(`/favorites/${lotId}`),
+        expect.objectContaining({
+          headers: { 'Authorization': `Bearer ${accessToken}` }
+        })
+      );
+    });
+  });
+
+  describe('requestWithRetry', () => {
+    it('refreshes token and retries the request upon a 401 error', async () => {
+      const unauthorizedError = { status: 401 };
+      const newAuth = { accessToken: 'mock-refreshed-token', userId };
+      const successResponse = { success: true, data: undefined };
+
+      mockApiService.post.mockRejectedValueOnce(unauthorizedError);
+      mockRefreshSession.mockResolvedValueOnce(newAuth);
+      mockApiService.post.mockResolvedValueOnce(successResponse);
+
+      await favoritesApi.addFavorite(userId, accessToken, lotId, mockRefreshSession);
+
+      expect(mockRefreshSession).toHaveBeenCalledTimes(1);
+
+      expect(mockApiService.post).toHaveBeenCalledTimes(2);
+      expect(mockApiService.post).toHaveBeenLastCalledWith(
+        expect.any(String),
+        {},
+        expect.objectContaining({
+          headers: { 'Authorization': `Bearer ${newAuth.accessToken}` }
+        })
+      );
+    });
+
+    it('throws the original error if refreshSession returns null', async () => {
+      const unauthorizedError = { status: 401 };
+
+      mockApiService.get.mockRejectedValueOnce(unauthorizedError);
+      mockRefreshSession.mockResolvedValueOnce(null);
+
+      await expect(
+        favoritesApi.getAllFavorites(userId, accessToken, mockRefreshSession)
+      ).rejects.toMatchObject({ status: 401 });
+    });
+  });
+});

--- a/apps/mobile/__tests__/useFavorites.test.ts
+++ b/apps/mobile/__tests__/useFavorites.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for useFavorite hooks
+ */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { useFavorites, UseFavoritesReturn } from '../src/hooks/useFavorites';
+import { useAuth } from '../src/context/AuthContext';
+import { AuthResult } from '../src/auth/AzureAuth';
+import favoritesApi from '../src/services/api/favorites';
+
+jest.mock('../src/context/AuthContext');
+jest.mock('../src/services/api/favorites');
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockFavoritesApi = favoritesApi as jest.Mocked<typeof favoritesApi>;
+
+/**
+ * Harness to test hook functionality, due to the lack of a testing library
+ */
+function HookTestComponent({ onHookValue }: { onHookValue: (val: UseFavoritesReturn) => void }) {
+  const hookVal = useFavorites();
+  onHookValue(hookVal);
+  return null;
+}
+
+describe('useFavorites hooks', () => {
+  const mockUser: AuthResult = {
+    accessToken: 'mock-access-token',
+    idToken: 'mock-id-token',
+    refreshToken: 'mock-refresh-token',
+    accessTokenExpirationDate: new Date().toISOString(),
+    tokenType: 'Bearer',
+    userId: 'test-user-id',
+  };
+
+  const mockRefresh = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      user: mockUser,
+      refreshSession: mockRefresh,
+      isAuthenticated: true,
+      login: jest.fn(),
+      logout: jest.fn(),
+      isLoading: false,
+    });
+  });
+
+  describe('refreshFavorites', () => {
+    it('fetches favorite lots on component mount', async () => {
+      const mockLots = ['G1', 'G3'];
+      mockFavoritesApi.getAllFavorites.mockResolvedValueOnce(mockLots);
+
+      let hookResult: UseFavoritesReturn;
+      // Manually capture hook state
+      const capture = (val: UseFavoritesReturn) => { hookResult = val; };
+
+      // Simulating the effect trigger
+      await (async () => {
+        await favoritesApi.getAllFavorites(mockUser.userId, mockUser.accessToken, mockRefresh);
+      })();
+
+      expect(mockFavoritesApi.getAllFavorites).toHaveBeenCalledWith(
+        mockUser.userId,
+        mockUser.accessToken,
+        mockRefresh
+      );
+    });
+  });
+
+  describe('Optimistic updates', () => {
+    it('handles optimistic updates correctly', async () => {
+      const newLot = 'G5';
+      mockFavoritesApi.addFavorite.mockResolvedValueOnce(undefined);
+
+      const state: string[] = ['G1'];
+      const optimisticState = [...state, newLot];
+
+      expect(optimisticState).toContain(newLot);
+
+      await favoritesApi.addFavorite(mockUser.userId, mockUser.accessToken, newLot, mockRefresh);
+      expect(mockFavoritesApi.addFavorite).toHaveBeenCalled();
+    });
+
+    it('rollbacks state if the API fails', async () => {
+      const failedLot = 'G10';
+      mockFavoritesApi.addFavorite.mockRejectedValueOnce(new Error('API Fail'));
+
+      let favoriteLots: string[] = [];
+      try {
+        favoriteLots = [failedLot];
+        await favoritesApi.addFavorite(mockUser.userId, mockUser.accessToken, failedLot, mockRefresh);
+      } catch (e) {
+        favoriteLots = favoriteLots.filter(id => id !== failedLot);
+      }
+
+      expect(favoriteLots).not.toContain(failedLot);
+    });
+  });
+
+  describe('AuthGuard verification', () => {
+    it('does not perform operations if user is null', async () => {
+      mockUseAuth.mockReturnValue({
+        user: null,
+        refreshSession: mockRefresh,
+        isAuthenticated: false,
+        login: jest.fn(),
+        logout: jest.fn(),
+        isLoading: false,
+      });
+
+      const userId = null;
+      if (!userId) {
+         expect(mockFavoritesApi.getAllFavorites).not.toHaveBeenCalled();
+      }
+    });
+  });
+});

--- a/apps/mobile/__tests__/useFavorites.test.ts
+++ b/apps/mobile/__tests__/useFavorites.test.ts
@@ -2,7 +2,8 @@
  * Tests for useFavorite hooks
  */
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { useFavorites, UseFavoritesReturn } from '../src/hooks/useFavorites';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useFavorites } from '../src/hooks/useFavorites';
 import { useAuth } from '../src/context/AuthContext';
 import { AuthResult } from '../src/auth/AzureAuth';
 import favoritesApi from '../src/services/api/favorites';
@@ -12,15 +13,6 @@ jest.mock('../src/services/api/favorites');
 
 const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const mockFavoritesApi = favoritesApi as jest.Mocked<typeof favoritesApi>;
-
-/**
- * Harness to test hook functionality, due to the lack of a testing library
- */
-function HookTestComponent({ onHookValue }: { onHookValue: (val: UseFavoritesReturn) => void }) {
-  const hookVal = useFavorites();
-  onHookValue(hookVal);
-  return null;
-}
 
 describe('useFavorites hooks', () => {
   const mockUser: AuthResult = {
@@ -51,68 +43,121 @@ describe('useFavorites hooks', () => {
       const mockLots = ['G1', 'G3'];
       mockFavoritesApi.getAllFavorites.mockResolvedValueOnce(mockLots);
 
-      let hookResult: UseFavoritesReturn;
-      // Manually capture hook state
-      const capture = (val: UseFavoritesReturn) => { hookResult = val; };
+      const { result } = renderHook(() => useFavorites());
+      expect(result.current.isLoading).toBe(true);
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      // Simulating the effect trigger
-      await (async () => {
-        await favoritesApi.getAllFavorites(mockUser.userId, mockUser.accessToken, mockRefresh);
-      })();
-
-      expect(mockFavoritesApi.getAllFavorites).toHaveBeenCalledWith(
-        mockUser.userId,
-        mockUser.accessToken,
-        mockRefresh
-      );
+      expect(result.current.favoriteLots).toEqual(mockLots);
+      expect(mockFavoritesApi.getAllFavorites).toHaveBeenCalled();
     });
   });
 
-  describe('Optimistic updates', () => {
-    it('handles optimistic updates correctly', async () => {
-      const newLot = 'G5';
+  describe('addFavorite', () => {
+    it('performs optimistic update and handles success', async () => {
+      mockFavoritesApi.getAllFavorites.mockResolvedValueOnce([]);
       mockFavoritesApi.addFavorite.mockResolvedValueOnce(undefined);
 
-      const state: string[] = ['G1'];
-      const optimisticState = [...state, newLot];
+      const { result } = renderHook(() => useFavorites());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(optimisticState).toContain(newLot);
+      let addPromise: Promise<void>;
+      act(() => {
+        addPromise = result.current.addFavorite('G5');
+      });
 
-      await favoritesApi.addFavorite(mockUser.userId, mockUser.accessToken, newLot, mockRefresh);
-      expect(mockFavoritesApi.addFavorite).toHaveBeenCalled();
+      expect(result.current.favoriteLots).toContain('G5');
+
+      await act(async () => {
+        await addPromise;
+      });
+
+      expect(result.current.favoriteLots).toContain('G5');
     });
 
-    it('rollbacks state if the API fails', async () => {
-      const failedLot = 'G10';
-      mockFavoritesApi.addFavorite.mockRejectedValueOnce(new Error('API Fail'));
+    it('rolls back state if addFavorite API fails', async () => {
+      mockFavoritesApi.getAllFavorites.mockResolvedValueOnce(['G1']);
+      mockFavoritesApi.addFavorite.mockRejectedValueOnce(new Error('API Failure'));
 
-      let favoriteLots: string[] = [];
-      try {
-        favoriteLots = [failedLot];
-        await favoritesApi.addFavorite(mockUser.userId, mockUser.accessToken, failedLot, mockRefresh);
-      } catch (e) {
-        favoriteLots = favoriteLots.filter(id => id !== failedLot);
-      }
+      const { result } = renderHook(() => useFavorites());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(favoriteLots).not.toContain(failedLot);
+      await act(async () => {
+        try {
+          await result.current.addFavorite('G10');
+        } catch {
+          /* Expected throw */
+        }
+      });
+
+      expect(result.current.favoriteLots).not.toContain('G10');
+      expect(result.current.favoriteLots).toEqual(['G1']);
     });
   });
 
-  describe('AuthGuard verification', () => {
-    it('does not perform operations if user is null', async () => {
+  describe('removeFavorite', () => {
+    it('performs optimistic update and handles success', async () => {
+      const initialLots = ['G1', 'G2'];
+      mockFavoritesApi.getAllFavorites.mockResolvedValueOnce(initialLots);
+      mockFavoritesApi.removeFavorite.mockResolvedValueOnce(undefined);
+
+      const { result } = renderHook(() => useFavorites());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      let removePromise: Promise<void>;
+      act(() => {
+        removePromise = result.current.removeFavorite('G1');
+      });
+
+      expect(result.current.favoriteLots).not.toContain('G1');
+      expect(result.current.favoriteLots).toEqual(['G2']);
+
+      await act(async () => {
+        await removePromise;
+      });
+    });
+
+    it('rolls back state if removeFavorite API fails', async () => {
+      mockFavoritesApi.getAllFavorites.mockResolvedValueOnce(['G1']);
+      mockFavoritesApi.removeFavorite.mockRejectedValueOnce(new Error('API Failure'));
+
+      const { result } = renderHook(() => useFavorites());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        try {
+          await result.current.removeFavorite('G1');
+        } catch {
+          /* Expected throw */
+        }
+      });
+
+      expect(result.current.favoriteLots).toContain('G1');
+      expect(result.current.error).toBeTruthy();
+    });
+  });
+
+  describe('Authentication clear', () => {
+    it('clears state and skips fetch if user logs out', async () => {
+      mockFavoritesApi.getAllFavorites.mockResolvedValueOnce(['G1']);
+
+      const { result, rerender } = renderHook(() => useFavorites());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
       mockUseAuth.mockReturnValue({
         user: null,
         refreshSession: mockRefresh,
         isAuthenticated: false,
+        isLoading: false,
         login: jest.fn(),
         logout: jest.fn(),
-        isLoading: false,
       });
 
-      const userId = null;
-      if (!userId) {
-         expect(mockFavoritesApi.getAllFavorites).not.toHaveBeenCalled();
-      }
+      await act(async () => {
+        rerender({});
+      });
+
+      expect(result.current.favoriteLots).toEqual([]);
+      expect(mockFavoritesApi.getAllFavorites).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -39,6 +39,7 @@
     "@react-native/babel-preset": "0.82.1",
     "@react-native/metro-config": "0.82.1",
     "@react-native/typescript-config": "0.82.1",
+    "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.1.1",
     "@types/react-native-vector-icons": "^6.4.18",

--- a/apps/mobile/src/auth/AzureAuth.tsx
+++ b/apps/mobile/src/auth/AzureAuth.tsx
@@ -40,11 +40,13 @@ const config = {
   issuer: `https://login.microsoftonline.com/${AZURE_CONFIG.TENANT_ID}/v2.0`,
   clientId: AZURE_CONFIG.CLIENT_ID,
   redirectUrl: REDIRECT_URL,
-  scopes: ['openid',
-           'profile',
-           'email',
-           'offline_access',
-           `api://${AZURE_CONFIG.CLIENT_ID}/access_as_user`],
+  scopes: [
+    'openid',
+    'profile',
+    'email',
+    'offline_access',
+    `api://${AZURE_CONFIG.CLIENT_ID}/access_as_user`
+  ],
   serviceConfiguration: {
     authorizationEndpoint: `https://login.microsoftonline.com/${AZURE_CONFIG.TENANT_ID}/oauth2/v2.0/authorize`,
     tokenEndpoint: `https://login.microsoftonline.com/${AZURE_CONFIG.TENANT_ID}/oauth2/v2.0/token`,
@@ -217,11 +219,11 @@ export const logoutFromAzure = async (idToken?: string): Promise<void> => {
         const errorMessage = (logoutError as Error).message || '';
         
         // Check if user explicitly cancelled the logout
-//         if (errorMessage.includes('User cancelled') || errorMessage.includes('cancel')) {
-//           log('[AzureAuth] User cancelled logout');
-//           // User cancelled - don't clear local state
-//           throw logoutError;
-//         }
+        if (errorMessage.includes('User cancelled') || errorMessage.includes('cancel')) {
+          log('[AzureAuth] User cancelled logout');
+          // User cancelled - don't clear local state
+          throw logoutError;
+        }
         
         // AppAuth error -3 (OIDErrorCodeUserCanceledAuthorizationFlow) is expected with Azure AD
         // The logout endpoint clears the session but doesn't redirect back properly

--- a/apps/mobile/src/auth/AzureAuth.tsx
+++ b/apps/mobile/src/auth/AzureAuth.tsx
@@ -40,7 +40,11 @@ const config = {
   issuer: `https://login.microsoftonline.com/${AZURE_CONFIG.TENANT_ID}/v2.0`,
   clientId: AZURE_CONFIG.CLIENT_ID,
   redirectUrl: REDIRECT_URL,
-  scopes: ['openid', 'profile', 'email', 'offline_access'],
+  scopes: ['openid',
+           'profile',
+           'email',
+           'offline_access',
+           `api://${AZURE_CONFIG.CLIENT_ID}/access_as_user`],
   serviceConfiguration: {
     authorizationEndpoint: `https://login.microsoftonline.com/${AZURE_CONFIG.TENANT_ID}/oauth2/v2.0/authorize`,
     tokenEndpoint: `https://login.microsoftonline.com/${AZURE_CONFIG.TENANT_ID}/oauth2/v2.0/token`,
@@ -72,19 +76,21 @@ export interface AuthResult {
   refreshToken?: string;
   accessTokenExpirationDate: string;
   tokenType: string;
+  userId: string;
 }
 
 // =============================================================================
 // Internal Helpers
 // =============================================================================
 
-/** Convert react-native-app-auth result to our AuthResult format */
-const toAuthResult = (result: AuthorizeResult | RefreshResult): AuthResult => ({
+/** Convert react-native-app-auth result to our AuthResult format (exempts email from latter) */
+const toAuthResult = (result: AuthorizeResult | RefreshResult, userEmail: string): AuthResult => ({
   accessToken: result.accessToken,
   idToken: result.idToken,
   refreshToken: result.refreshToken ?? undefined,
   accessTokenExpirationDate: result.accessTokenExpirationDate,
   tokenType: result.tokenType,
+  userId: userEmail
 });
 
 // =============================================================================
@@ -125,8 +131,7 @@ export const loginWithAzure = async (): Promise<AuthResult> => {
     // Sync user with backend (triggers findOrCreateUser)
     await syncUserWithBackend(result.idToken, userEmail);
 
-    return toAuthResult(result);
-
+    return toAuthResult(result, userEmail);
   } catch (error) {
     if (__DEV__) {
       console.error('[AzureAuth] Login failed:', error);
@@ -212,11 +217,11 @@ export const logoutFromAzure = async (idToken?: string): Promise<void> => {
         const errorMessage = (logoutError as Error).message || '';
         
         // Check if user explicitly cancelled the logout
-        if (errorMessage.includes('User cancelled') || errorMessage.includes('cancel')) {
-          log('[AzureAuth] User cancelled logout');
-          // User cancelled - don't clear local state
-          throw logoutError;
-        }
+//         if (errorMessage.includes('User cancelled') || errorMessage.includes('cancel')) {
+//           log('[AzureAuth] User cancelled logout');
+//           // User cancelled - don't clear local state
+//           throw logoutError;
+//         }
         
         // AppAuth error -3 (OIDErrorCodeUserCanceledAuthorizationFlow) is expected with Azure AD
         // The logout endpoint clears the session but doesn't redirect back properly
@@ -280,7 +285,10 @@ export const loadAuth = async (): Promise<AuthResult | null> => {
 
     const authState: AuthResult = JSON.parse(credentials.password);
     const expirationDate = new Date(authState.accessTokenExpirationDate);
+    const userEmail: string = authState.userId;
     const now = new Date();
+
+    log('[AzureAuth] Logging in as user:', userEmail);
 
     // Token is still valid (with buffer for proactive refresh)
     if (now.getTime() < expirationDate.getTime() - TOKEN_REFRESH_BUFFER_MS) {
@@ -299,7 +307,7 @@ export const loadAuth = async (): Promise<AuthResult | null> => {
 
         log('[AzureAuth] Token refresh successful');
 
-        const newAuthState = toAuthResult(refreshResult);
+        const newAuthState = toAuthResult(refreshResult, userEmail);
         await saveAuth(newAuthState);
         return newAuthState;
 

--- a/apps/mobile/src/components/Modals/NavigationModal.tsx
+++ b/apps/mobile/src/components/Modals/NavigationModal.tsx
@@ -1,0 +1,204 @@
+import React, { useMemo } from 'react';
+import {
+  View, Text, Modal,
+  TouchableOpacity, ScrollView,
+  StyleSheet, Pressable,
+  ActivityIndicator
+} from 'react-native';
+import { COLORS, SPACING, TYPOGRAPHY } from '../../constants/theme';
+import { useLotsList } from '../../hooks/useLotData';
+import { getOccupancyColor } from '../../utils/parkingUtils';
+
+interface NavigationModalProps {
+  isOpen: boolean;
+  lotIdList: string[];
+  onClose: () => void;
+}
+
+export function NavigationModal({ isOpen, lotIdList, onClose }: NavigationModalProps) {
+  const { lots, loading } = useLotsList();
+
+  const displayLots = useMemo(() => {
+    if (!lotIdList) return [];
+    return lots.filter(lot => lotIdList.includes(lot.lot_id));
+  }, [lots, lotIdList]);
+
+  const handleLotPress = (lotId: string) => {
+    // TODO: open third-party map service (dependent: real-world lot coordinates)
+    if (__DEV__) console.log(`[NavigationModal] ${lotId} selected for navigation`);
+  };
+
+  return (
+    <Modal
+      visible={isOpen}
+      transparent
+      onRequestClose={onClose}
+    >
+      <View style={styles.backdrop}>
+        <Pressable style={styles.backdropPress} onPress={onClose} />
+
+        <View style={styles.modal}>
+          <View style={styles.header}>
+            <Text style={styles.title}>Lot Navigation Selection</Text>
+            <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+              <Text style={styles.closeIcon}>✕</Text>
+            </TouchableOpacity>
+          </View>
+
+          {loading ? (
+            <View style={styles.loaderContainer}>
+              <ActivityIndicator size="large" color={COLORS.primary} />
+            </View>
+          ) : displayLots.length === 0 ? (
+                /* Empty State View */
+                <View style={styles.emptyContainer}>
+                  <Text style={styles.emptyTitle}>No Favorites Yet</Text>
+                  <Text style={styles.emptySubtext}>
+                    Favorited lots will appear here for quick navigation.
+                  </Text>
+                </View>
+          ) : (
+            <ScrollView contentContainerStyle={styles.scrollContent}>
+              {displayLots.map((lot) => (
+                <TouchableOpacity
+                  key={lot.lot_id}
+                  style={styles.lotRow}
+                  onPress={() => handleLotPress(lot.lot_id)}
+                  activeOpacity={0.7}
+                >
+                  <View style={styles.infoContainer}>
+                    <Text style={styles.lotName}>{lot.lot_name}</Text>
+                    <Text style={styles.occupancyText}>
+                      ~{Math.round(lot.occupancy_rate * lot.capacity)} / {lot.capacity} spots taken
+                    </Text>
+
+                    {/* Visual Occupancy Bar */}
+                    <View style={styles.progressBarBg}>
+                      <View
+                        style={[
+                          styles.progressBarFill,
+                          {width: `${Math.round(lot.occupancy_rate * 100)}%`},
+                          {backgroundColor: getOccupancyColor(Math.round(lot.occupancy_rate * 100))}
+                        ]}
+                      />
+                    </View>
+                  </View>
+
+                  <Text style={styles.arrow}>›</Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: SPACING.xl,
+  },
+  backdropPress: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  modal: {
+    backgroundColor: COLORS.white,
+    borderRadius: SPACING.xl,
+    width: '100%',
+    maxWidth: 448,
+    maxHeight: '85%',
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: SPACING.xl,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.borderGray,
+  },
+  title: {
+    fontSize: TYPOGRAPHY.fontSize.xl,
+    fontWeight: TYPOGRAPHY.fontWeight.semibold,
+    color: COLORS.textPrimary,
+  },
+  scrollContent: {
+    padding: SPACING.lg,
+  },
+  lotRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: COLORS.lightGray,
+    padding: SPACING.xl,
+    borderRadius: SPACING.md,
+    marginBottom: SPACING.md,
+  },
+  infoContainer: {
+    flex: 1,
+  },
+  lotName: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: COLORS.textPrimary,
+  },
+  occupancyText: {
+    fontSize: 14,
+    color: COLORS.mediumGray,
+    marginVertical: 4,
+  },
+  progressBarBg: {
+    height: 8,
+    backgroundColor: COLORS.borderGray,
+    borderRadius: 4,
+    overflow: 'hidden',
+    marginTop: 4,
+    width: '80%',
+  },
+  progressBarFill: {
+    height: '100%',
+    backgroundColor: COLORS.primary,
+  },
+  arrow: {
+    fontSize: 24,
+    color: COLORS.mediumGray,
+    marginLeft: SPACING.md,
+  },
+  loaderContainer: {
+    padding: 50,
+    alignItems: 'center',
+  },
+  closeIcon: {
+    fontSize: 20,
+    color: COLORS.mediumGray,
+  },
+  closeButton: {
+    padding: 8,
+    borderRadius: 20,
+  },
+  emptyContainer: {
+    padding: SPACING.xl,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyTitle: {
+    fontSize: TYPOGRAPHY.fontSize.lg,
+    fontWeight: TYPOGRAPHY.fontWeight.semibold,
+    color: COLORS.darkGray,
+    marginBottom: SPACING.xs,
+  },
+  emptySubtext: {
+    fontSize: TYPOGRAPHY.fontSize.md,
+    color: COLORS.mediumGray,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+});

--- a/apps/mobile/src/components/Modals/NavigationModal.tsx
+++ b/apps/mobile/src/components/Modals/NavigationModal.tsx
@@ -9,18 +9,32 @@ import { COLORS, SPACING, TYPOGRAPHY } from '../../constants/theme';
 import { useLotsList } from '../../hooks/useLotData';
 import { getOccupancyColor } from '../../utils/parkingUtils';
 
+// Defines what text to display in the case of an empty lots list
+const EMPTY_CONTENT = {
+  favorites: {
+    title: "No Favorites Yet",
+    subtext: "Favorited lots will appear here for quick navigation."
+  },
+  recommended: {
+    title: "No Recommendations",
+    subtext: "No lots could be recommended at this time."
+  }
+};
+
 interface NavigationModalProps {
   isOpen: boolean;
   lotIdList: string[];
   onClose: () => void;
   onSelectLot: (lotId: string, lotName: string) => void;
+  mode: 'favorites' | 'recommended';
 }
 
-export function NavigationModal({ isOpen, lotIdList, onClose, onSelectLot }: NavigationModalProps) {
+export function NavigationModal({ isOpen, lotIdList, onClose, onSelectLot, mode }: NavigationModalProps) {
+  const currentContent = EMPTY_CONTENT[mode];
   const { lots, loading } = useLotsList();
 
   const displayLots = useMemo(() => {
-    if (!lotIdList) return [];
+    if (!lotIdList || lotIdList.length === 0) return [];
     return lots.filter(lot => lotIdList.includes(lot.lot_id));
   }, [lots, lotIdList]);
 
@@ -53,10 +67,8 @@ export function NavigationModal({ isOpen, lotIdList, onClose, onSelectLot }: Nav
           ) : displayLots.length === 0 ? (
                 /* Empty State View */
                 <View style={styles.emptyContainer}>
-                  <Text style={styles.emptyTitle}>No Favorites Yet</Text>
-                  <Text style={styles.emptySubtext}>
-                    Favorited lots will appear here for quick navigation.
-                  </Text>
+                  <Text style={styles.emptyTitle}>{currentContent.title}</Text>
+                  <Text style={styles.emptySubtext}>{currentContent.subtext}</Text>
                 </View>
           ) : (
             <ScrollView contentContainerStyle={styles.scrollContent}>

--- a/apps/mobile/src/components/Modals/NavigationModal.tsx
+++ b/apps/mobile/src/components/Modals/NavigationModal.tsx
@@ -13,9 +13,10 @@ interface NavigationModalProps {
   isOpen: boolean;
   lotIdList: string[];
   onClose: () => void;
+  onSelectLot: (lotId: string, lotName: string) => void;
 }
 
-export function NavigationModal({ isOpen, lotIdList, onClose }: NavigationModalProps) {
+export function NavigationModal({ isOpen, lotIdList, onClose, onSelectLot }: NavigationModalProps) {
   const { lots, loading } = useLotsList();
 
   const displayLots = useMemo(() => {
@@ -23,9 +24,9 @@ export function NavigationModal({ isOpen, lotIdList, onClose }: NavigationModalP
     return lots.filter(lot => lotIdList.includes(lot.lot_id));
   }, [lots, lotIdList]);
 
-  const handleLotPress = (lotId: string) => {
-    // TODO: open third-party map service (dependent: real-world lot coordinates)
-    if (__DEV__) console.log(`[NavigationModal] ${lotId} selected for navigation`);
+  const handleLotPress = (lotId: string, lotName: string) => {
+    onClose();
+    onSelectLot(lotId, lotName);
   };
 
   return (
@@ -63,13 +64,13 @@ export function NavigationModal({ isOpen, lotIdList, onClose }: NavigationModalP
                 <TouchableOpacity
                   key={lot.lot_id}
                   style={styles.lotRow}
-                  onPress={() => handleLotPress(lot.lot_id)}
+                  onPress={() => handleLotPress(lot.lot_id, lot.lot_name)}
                   activeOpacity={0.7}
                 >
                   <View style={styles.infoContainer}>
                     <Text style={styles.lotName}>{lot.lot_name}</Text>
                     <Text style={styles.occupancyText}>
-                      ~{Math.round(lot.occupancy_rate * lot.capacity)} / {lot.capacity} spots taken
+                      Estimate: {Math.round(lot.occupancy_rate * lot.capacity)} / {lot.capacity} spots taken
                     </Text>
 
                     {/* Visual Occupancy Bar */}

--- a/apps/mobile/src/components/NavigationSpeedDial.tsx
+++ b/apps/mobile/src/components/NavigationSpeedDial.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { COLORS, SPACING } from '../constants/theme';
+
+interface NavigationSpeedDialProps {
+  onSelectRecommended: () => void;
+  onSelectFavorites: () => void;
+  // Passing in the navigation button from the MapScreen
+  renderTrigger: (isOpen: boolean, toggle: () => void) => React.ReactNode;
+}
+
+export const NavigationSpeedDial = ({ onSelectRecommended, onSelectFavorites, renderTrigger }: NavigationSpeedDialProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleMenu = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleAction = (action: () => void) => {
+    action();
+    setIsOpen(false); // Close menu after selection
+  };
+
+  return (
+    <View style={styles.container} pointerEvents="box-none">
+      {isOpen && (
+        <View style={styles.pillContainer}>
+          <TouchableOpacity
+            style={styles.pill}
+            onPress={() => handleAction(onSelectRecommended)}
+          >
+            <Text style={styles.pillText}>Recommended</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.pill}
+            onPress={() => handleAction(onSelectFavorites)}
+          >
+            <Text style={styles.pillText}>Favorite Lots</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {/* Render NavigateButton from MapScreen */}
+      {renderTrigger(isOpen, toggleMenu)}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: SPACING.xxl, // Same as filter button
+    right: SPACING.xxl, // Symmetric position on the right
+    alignItems: 'flex-end',
+  },
+  pillContainer: {
+    marginBottom: SPACING.md,
+    gap: SPACING.sm,
+  },
+  pill: {
+    backgroundColor: COLORS.white,
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 25,
+    elevation: 4,
+    shadowColor: COLORS.shadowDark,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 3,
+  },
+  pillText: {
+    color: COLORS.secondary,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/src/context/AuthContext.tsx
+++ b/apps/mobile/src/context/AuthContext.tsx
@@ -8,6 +8,7 @@ interface AuthContextType {
   user: AuthState | null;
   login: () => Promise<void>;
   logout: () => Promise<void>;
+  refreshSession: () => Promise<AuthState | null>;
   isLoading: boolean;
 }
 
@@ -80,8 +81,22 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     setIsAuthenticated(false);
   };
 
+  // Handle Session Refresh
+  const refreshSession = async (): Promise<AuthState | null> => {
+    const savedUser = await loadAuth();
+    if (!savedUser) {
+      if (__DEV__) console.log('[AuthContext] Refresh failed, logging user out...');
+      setUser(null);
+      setIsAuthenticated(false);
+    } else {
+      if (__DEV__) console.log('[AuthContext] Refresh succeeded, returning new credentials...');
+      setUser(savedUser);
+    }
+    return savedUser;
+  };
+
   return (
-    <AuthContext.Provider value={{ isAuthenticated, user, login, logout, isLoading }}>
+    <AuthContext.Provider value={{ isAuthenticated, user, login, logout, refreshSession, isLoading }}>
       {children}
     </AuthContext.Provider>
   );

--- a/apps/mobile/src/hooks/useFavorites.ts
+++ b/apps/mobile/src/hooks/useFavorites.ts
@@ -8,7 +8,7 @@ import favoritesApi from '../services/api/favorites';
 import { ApiError } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 
-interface UseFavoritesReturn {
+export interface UseFavoritesReturn {
   favoriteLots: string[];
   isLoading: boolean;
   error: string | null;

--- a/apps/mobile/src/hooks/useFavorites.ts
+++ b/apps/mobile/src/hooks/useFavorites.ts
@@ -1,0 +1,101 @@
+/**
+ * Hook for accessing & managing user's favorite lots
+ *   Responsible for retrieving & managing a local copy of the user's favorites list
+ *   A valid userId & accessToken are required
+ */
+import { useState, useEffect, useCallback } from 'react';
+import favoritesApi from '../services/api/favorites';
+import { ApiError } from '../services/api';
+import { useAuth } from '../context/AuthContext';
+
+interface UseFavoritesReturn {
+  favoriteLots: string[];
+  isLoading: boolean;
+  error: string | null;
+  addFavorite: (lotId: string) => Promise<void>;
+  removeFavorite: (lotId: string) => Promise<void>;
+  refreshFavorites: () => Promise<string[]>;
+}
+
+export const useFavorites = (): UseFavoritesReturn => {
+  const { user, refreshSession } = useAuth();
+  const [favoriteLots, setFavoriteLots] = useState<string[]>([]);
+  const [isLoading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const userId = user?.userId;
+  const accessToken = user?.accessToken;
+
+  useEffect(() => {
+    refreshFavorites();
+  }, [userId, accessToken]);
+
+  // Add the lot to the user's favorites list & return a copy
+  const refreshFavorites = useCallback(async (): Promise<string[]> => {
+    if (!userId || !accessToken) return [];
+
+    try {
+      setLoading(true);
+      setError(null);
+      const favorites = await favoritesApi.getAllFavorites(userId, accessToken, refreshSession);
+      setFavoriteLots(favorites);
+      return favorites;
+    } catch (error) {
+      const errorMessage = error instanceof ApiError
+        ? `${error.message} (${error.status})`
+        : `[useFavorites] Retrieving favorites failed for ${userId}`;
+      setError(errorMessage);
+    } finally {
+      setLoading(false);
+    } return [];
+  }, [userId, accessToken]);
+
+  // Add the lot to the user's favorites list
+  const addFavorite = useCallback(async (lotId: string): Promise<void> => {
+    if (!userId || !accessToken) return;
+
+    // Optimistic local update
+    setFavoriteLots((prev) => [...prev, lotId]);
+
+    try {
+      setError(null);
+      await favoritesApi.addFavorite(userId, accessToken, lotId, refreshSession);
+    } catch (error) {
+      // Rollback on failure
+      setFavoriteLots((prev) => prev.filter(fav => fav !== lotId));
+
+      const errorMessage = error instanceof ApiError
+        ? `${error.message} (${error.status})`
+        : `[useFavorites] Failed to favorite lot ${lotId} for ${userId}`;
+      setError(errorMessage);
+      throw error;
+    }
+  }, [userId, accessToken]);
+
+  // Remove the lot from the user's favorites list
+  const removeFavorite = useCallback(async (lotId: string): Promise<void> => {
+    if (!userId || !accessToken) return;
+
+    // Optimistic local update
+    const previousFavorites = [...favoriteLots];
+    setFavoriteLots((prev) => prev.filter(fav => fav !== lotId));
+
+    try {
+      setError(null);
+      await favoritesApi.removeFavorite(userId, accessToken, lotId, refreshSession);
+    } catch (error) {
+      // Rollback on failure
+      setFavoriteLots(previousFavorites);
+
+      const errorMessage = error instanceof ApiError
+        ? `${error.message} (${error.status})`
+        : `[useFavorites] Failed to unfavorite lot ${lotId} for ${userId}`;
+      setError(errorMessage);
+      throw error;
+    }
+  }, [favoriteLots, userId, accessToken]);
+
+  return { favoriteLots, isLoading, error, addFavorite, removeFavorite, refreshFavorites};
+};
+
+export default useFavorites;

--- a/apps/mobile/src/hooks/useFavorites.ts
+++ b/apps/mobile/src/hooks/useFavorites.ts
@@ -3,12 +3,12 @@
  *   Responsible for retrieving & managing a local copy of the user's favorites list
  *   A valid userId & accessToken are required
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import favoritesApi from '../services/api/favorites';
 import { ApiError } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 
-export interface UseFavoritesReturn {
+interface UseFavoritesReturn {
   favoriteLots: string[];
   isLoading: boolean;
   error: string | null;
@@ -23,12 +23,11 @@ export const useFavorites = (): UseFavoritesReturn => {
   const [isLoading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
+  const favoritesRef = useRef(favoriteLots);
+  favoritesRef.current = favoriteLots;
+
   const userId = user?.userId;
   const accessToken = user?.accessToken;
-
-  useEffect(() => {
-    refreshFavorites();
-  }, [userId, accessToken]);
 
   // Add the lot to the user's favorites list & return a copy
   const refreshFavorites = useCallback(async (): Promise<string[]> => {
@@ -45,16 +44,27 @@ export const useFavorites = (): UseFavoritesReturn => {
         ? `${error.message} (${error.status})`
         : `[useFavorites] Retrieving favorites failed for ${userId}`;
       setError(errorMessage);
+      return [];
     } finally {
       setLoading(false);
-    } return [];
+    }
   }, [userId, accessToken]);
+
+  useEffect(() => {
+    if (!userId) {
+      setFavoriteLots([]); // Clear local state on logout
+      setLoading(false);
+    } else {
+      refreshFavorites();
+    }
+  }, [userId, refreshFavorites]);
 
   // Add the lot to the user's favorites list
   const addFavorite = useCallback(async (lotId: string): Promise<void> => {
     if (!userId || !accessToken) return;
 
     // Optimistic local update
+    const previousFavorites = [...favoritesRef.current];
     setFavoriteLots((prev) => [...prev, lotId]);
 
     try {
@@ -62,7 +72,7 @@ export const useFavorites = (): UseFavoritesReturn => {
       await favoritesApi.addFavorite(userId, accessToken, lotId, refreshSession);
     } catch (error) {
       // Rollback on failure
-      setFavoriteLots((prev) => prev.filter(fav => fav !== lotId));
+      setFavoriteLots(previousFavorites);
 
       const errorMessage = error instanceof ApiError
         ? `${error.message} (${error.status})`
@@ -77,7 +87,7 @@ export const useFavorites = (): UseFavoritesReturn => {
     if (!userId || !accessToken) return;
 
     // Optimistic local update
-    const previousFavorites = [...favoriteLots];
+    const previousFavorites = [...favoritesRef.current];
     setFavoriteLots((prev) => prev.filter(fav => fav !== lotId));
 
     try {
@@ -93,7 +103,7 @@ export const useFavorites = (): UseFavoritesReturn => {
       setError(errorMessage);
       throw error;
     }
-  }, [favoriteLots, userId, accessToken]);
+  }, [userId, accessToken]);
 
   return { favoriteLots, isLoading, error, addFavorite, removeFavorite, refreshFavorites};
 };

--- a/apps/mobile/src/screens/MapScreen.tsx
+++ b/apps/mobile/src/screens/MapScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
   View,
   StyleSheet,
@@ -79,6 +79,7 @@ const MapScreen: React.FC = () => {
   const [isNavigationModalOpen, setIsNavigationModalOpen] = useState(false);
   const { refreshFavorites } = useFavorites();
   const [navigableLots, setNavigableLots] = useState<string[]>([]);
+  const [navigationMode, setNavigationMode] = useState<'favorites' | 'recommended'>('recommended');
   const navigation = useNavigation<StackNavigationProp<MapStackParamList>>();
   
   // Shared values for map transformations (pan and zoom)
@@ -195,16 +196,17 @@ const MapScreen: React.FC = () => {
     });
   };
 
-  const openNavigationModal = async (type: 'favorites' | 'recommended') => {
+  const openNavigationModal = useCallback(async (type: 'favorites' | 'recommended') => {
+    setNavigationMode(type);
     if (type === 'favorites') {
       const favoriteLots = await refreshFavorites(); // Ensures that current instance of favoriteLots is up-to-date
       setNavigableLots(favoriteLots);
     } else {
-      // TODO: Implement lot recommendation system; using all lots as a placeholder
-      setNavigableLots(parkingLots.map(lot => lot.id));
+      // TODO: Implement lot recommendation system
+      setNavigableLots([]);
     }
     setIsNavigationModalOpen(true);
-  };
+  }, [refreshFavorites]);
 
   // Filter parking lots based on selected filter
   const filteredParkingLots = selectedLots.length > 0 
@@ -279,6 +281,7 @@ const MapScreen: React.FC = () => {
         lotIdList={navigableLots}
         onClose={handleNavigateClose}
         onSelectLot={(id, name) => handleLotNavigation(id, name)}
+        mode={navigationMode}
       />
     </View>
   );

--- a/apps/mobile/src/screens/MapScreen.tsx
+++ b/apps/mobile/src/screens/MapScreen.tsx
@@ -16,11 +16,14 @@ import { getOccupancyColor } from '../utils/parkingUtils';
 import { ParkingLotUI } from '../types/ui';
 import { Header } from '../components';
 import { LotFilterModal } from '../components/Modals/FilterModal';
+import { NavigationModal } from '../components/Modals/NavigationModal';
+import { NavigationSpeedDial } from '../components/NavigationSpeedDial';
 import { TYPOGRAPHY, SPACING, MAP } from '../constants/theme';
 import { useTheme, ThemeColors } from '../context/ThemeContext';
 import type { MapStackParamList } from '../types/navigation';
 import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+import useFavorites from '../hooks/useFavorites';
 
 const { width: screenWidth } = Dimensions.get('window');
 
@@ -73,6 +76,9 @@ const MapScreen: React.FC = () => {
   const { colors } = useTheme();
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
   const [selectedLots, setSelectedLots] = useState<string[]>([]);
+  const [isNavigationModalOpen, setIsNavigationModalOpen] = useState(false);
+  const { refreshFavorites } = useFavorites();
+  const [navigableLots, setNavigableLots] = useState<string[]>([]);
   const navigation = useNavigation<StackNavigationProp<MapStackParamList>>();
   
   // Shared values for map transformations (pan and zoom)
@@ -168,17 +174,28 @@ const MapScreen: React.FC = () => {
     setIsFilterModalOpen(true);
   };
 
-  const handleNavigatePress = () => {
-    // TODO: Add navigation logic here (e.g., open Google Maps to campus)
-  };
-
   const handleFilterClose = () => {
     setIsFilterModalOpen(false);
+  };
+
+  const handleNavigateClose = () => {
+    setIsNavigationModalOpen(false);
   };
 
   const handleApplyFilter = (filteredLots: string[]) => {
     setSelectedLots(filteredLots);
     setIsFilterModalOpen(false);
+  };
+
+  const openNavigationModal = async (type: 'favorites' | 'recommended') => {
+    if (type === 'favorites') {
+      const favoriteLots = await refreshFavorites(); // Ensures that current instance of favoriteLots is up-to-date
+      setNavigableLots(favoriteLots);
+    } else {
+      // TODO: Implement lot recommendation system; using all lots as a placeholder
+      setNavigableLots(parkingLots.map(lot => lot.id));
+    }
+    setIsNavigationModalOpen(true);
   };
 
   // Filter parking lots based on selected filter
@@ -228,8 +245,17 @@ const MapScreen: React.FC = () => {
       {/* Filter button - bottom left */}
       <FilterButton onPress={handleFilterPress} colors={colors} />
 
-      {/* Navigate button - bottom right */}
-      <NavigateButton onPress={handleNavigatePress} colors={colors} />
+      {/* Navigation speed dial via Navigate button FAB - bottom right */}
+      <NavigationSpeedDial
+        onSelectRecommended={() => openNavigationModal('recommended')}
+        onSelectFavorites={() => openNavigationModal('favorites')}
+        renderTrigger={(isOpen, toggle) => (
+          <NavigateButton
+            onPress={toggle}
+            colors={colors}
+          />
+        )}
+      />
 
       {/* Filter Modal */}
       <LotFilterModal
@@ -237,6 +263,13 @@ const MapScreen: React.FC = () => {
         onClose={handleFilterClose}
         selectedLots={selectedLots}
         onApplyFilter={handleApplyFilter}
+      />
+
+      {/* Navigation Modal */}
+      <NavigationModal
+        isOpen={isNavigationModalOpen}
+        lotIdList={navigableLots}
+        onClose={handleNavigateClose}
       />
     </View>
   );
@@ -297,9 +330,6 @@ const styles = StyleSheet.create({
     elevation: 8,
   },
   navigateButton: {
-    position: 'absolute',
-    bottom: SPACING.xxl, // Same as filter button
-    right: SPACING.xxl, // Symmetric position on the right
     width: 56,
     height: 56,
     borderRadius: 28,

--- a/apps/mobile/src/screens/MapScreen.tsx
+++ b/apps/mobile/src/screens/MapScreen.tsx
@@ -164,9 +164,9 @@ const MapScreen: React.FC = () => {
 
   const handleLotPress = (lot: ParkingLotUI) => {
     // Navigate to ShortTermForecastScreen with lot data
-    navigation.navigate('Short Term Forecast', { 
-      lotId: lot.id, 
-      lotName: lot.name 
+    navigation.navigate('Short Term Forecast', {
+      lotId: lot.id,
+      lotName: lot.name
     });
   };
 
@@ -185,6 +185,14 @@ const MapScreen: React.FC = () => {
   const handleApplyFilter = (filteredLots: string[]) => {
     setSelectedLots(filteredLots);
     setIsFilterModalOpen(false);
+  };
+
+  // Redirect to Short-Term Forecast Screen of the lot selected within the navigation modal
+  const handleLotNavigation = (id: string, name: string) => {
+    navigation.navigate('Short Term Forecast', {
+      lotId: id,
+      lotName: name
+    });
   };
 
   const openNavigationModal = async (type: 'favorites' | 'recommended') => {
@@ -270,6 +278,7 @@ const MapScreen: React.FC = () => {
         isOpen={isNavigationModalOpen}
         lotIdList={navigableLots}
         onClose={handleNavigateClose}
+        onSelectLot={(id, name) => handleLotNavigation(id, name)}
       />
     </View>
   );

--- a/apps/mobile/src/screens/ShortTermForecastScreen.tsx
+++ b/apps/mobile/src/screens/ShortTermForecastScreen.tsx
@@ -23,6 +23,13 @@ import { ReportModal } from '../components/Modals/ReportModal';
 import { ReliabilityModal } from '../components/Modals/ReliabilityModal';
 import type { MapStackScreenProps } from '../types/navigation';
 
+// Favorite button component
+const FavoriteButton: React.FC<{ isFavorite: boolean; onToggle: () => void }> = ({ isFavorite, onToggle }) => (
+  <TouchableOpacity onPress={onToggle} style={styles.favoriteButton}>
+    <Icon name={isFavorite ? "star" : "star-outline"} size={28} color={isFavorite ? COLORS.black : COLORS.darkGray} />
+  </TouchableOpacity>
+);
+
 // Navigation-aware component
 export function ShortTermForecastScreen() {
   const navigation = useNavigation();
@@ -116,13 +123,6 @@ export function ShortTermForecastScreen() {
       );
     }
   };
-
-  // Favorite button component
-  const FavoriteButton: React.FC<{ isFavorite: boolean; onToggle: () => void }> = ({ isFavorite, onToggle }) => (
-    <TouchableOpacity onPress={onToggle} style={styles.favoriteButton}>
-      <Icon name={isFavorite ? "star" : "star-outline"} size={28} color={isFavorite ? COLORS.black : COLORS.darkGray} />
-    </TouchableOpacity>
-  );
 
   return (
     <View style={[styles.container, { backgroundColor: colors.lightGray }]}>

--- a/apps/mobile/src/screens/ShortTermForecastScreen.tsx
+++ b/apps/mobile/src/screens/ShortTermForecastScreen.tsx
@@ -7,6 +7,7 @@ import { Header, ReliabilityMeter } from '../components';
 import { useTheme } from '../context/ThemeContext';
 import { useLotData } from '../hooks/useLotData';
 import { useReliability } from '../hooks/useReliability';
+import useFavorites from '../hooks/useFavorites';
 
 import {getOccupancyColor} from '../utils/parkingUtils';
 import {HourlyChart} from '../components/HourlyChart';
@@ -24,10 +25,15 @@ export function ShortTermForecastScreen() {
   // Use the API hook instead of mock data
   const { lot, forecast, loading, error, refreshLot } = useLotData(lotId);
   const { reliability, loading: reliabilityLoading } = useReliability(lotId);
-  
+
   const onBack = () => navigation.goBack();
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
   const [isReliabilityModalOpen, setIsReliabilityModalOpen] = useState(false);
+
+  // For favorites
+  const { addFavorite, removeFavorite, favoriteLots } = useFavorites();
+  // If the lotId is present in favoriteLots, then the lot is a favorite
+  const isFavorite = favoriteLots.some(fav => fav === lotId);
 
   // Show loading spinner while data is being fetched
   if (loading) {
@@ -90,10 +96,33 @@ export function ShortTermForecastScreen() {
 
   const todayEvents = getTodayEvents();
 
+  // Try to (un-)favorite a lot dependent on current isFavorite status
+  const toggleFavorite = async () => {
+    try {
+      isFavorite? await removeFavorite(lotId) : await addFavorite(lotId);
+    } catch {
+      Alert.alert(
+        'Favorite Lots Error',
+        'The favorite status of the lot could not be changed. Please try again.',
+        [{ text: 'OK', style: 'cancel' }]
+      );
+    }
+  };
+
+  // Favorite button component
+  const FavoriteButton: React.FC<{ isFavorite: boolean; onToggle: () => void }> = ({ isFavorite, onToggle }) => (
+    <TouchableOpacity onPress={onToggle} style={styles.favoriteButton}>
+      <Icon name={isFavorite ? "star" : "star-outline"} size={28} color={isFavorite ? COLORS.black : COLORS.darkGray} />
+    </TouchableOpacity>
+  );
+
   return (
     <View style={[styles.container, { backgroundColor: colors.lightGray }]}>
-      {/* Top Banner */}
-      <Header title="Short-Term Forecast" onBack={onBack}/>
+      {/* Top Banner & Favorite Button*/}
+      <View>
+        <Header title="Short-Term Forecast" onBack={onBack}/>
+        <FavoriteButton isFavorite={isFavorite} onToggle={toggleFavorite} />
+      </View>
 
       <ScrollView style={styles.scrollView}>
         {/* Event Notifications */}
@@ -120,7 +149,7 @@ export function ShortTermForecastScreen() {
           <View style={[styles.statusBadge, {backgroundColor: getOccupancyColor(Math.round(lot.occupancy_rate * 100))}]}>
             <Text style={styles.statusBadgeText}>{Math.round(lot.occupancy_rate * 100)}%</Text>
           </View>
-          
+
           {/* Reliability Meter */}
           {!reliabilityLoading && reliability && (
             <ReliabilityMeter
@@ -260,7 +289,15 @@ const styles = StyleSheet.create({
     marginTop: SPACING.xs,
   },
 
-  // Title card + Status
+  favoriteButton: {
+    position: 'absolute',
+    top: '50%',
+    right: SPACING.xxxl,
+    marginTop: -8, // Offset so that button is centered
+    padding: SPACING.xs,
+  },
+
+  // Title card + Status & Favorite Button
   lotHeaderCard: {
     borderRadius: SPACING.lg,
     padding: SPACING.xxxl,
@@ -331,6 +368,4 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     lineHeight: TYPOGRAPHY.fontSize.xxl,
   },
-
-
 });

--- a/apps/mobile/src/screens/ShortTermForecastScreen.tsx
+++ b/apps/mobile/src/screens/ShortTermForecastScreen.tsx
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
-import {View, Text, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator} from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert
+} from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import Icon from 'react-native-vector-icons/Ionicons';
 import { COLORS, TYPOGRAPHY, SPACING } from '../constants/theme';

--- a/apps/mobile/src/services/api/base.ts
+++ b/apps/mobile/src/services/api/base.ts
@@ -84,26 +84,28 @@ class ApiService {
     return controller.signal;
   }
 
-  async get<T>(endpoint: string): Promise<ApiResponse<T>> {
-    return this.makeRequest<T>(endpoint, { method: 'GET' });
+  async get<T>(endpoint: string, options: RequestInit = {}): Promise<ApiResponse<T>> {
+    return this.makeRequest<T>(endpoint, { ...options, method: 'GET' });
   }
 
-  async post<T>(endpoint: string, body: unknown): Promise<ApiResponse<T>> {
+  async post<T>(endpoint: string, body: unknown, options: RequestInit = {}): Promise<ApiResponse<T>> {
     return this.makeRequest<T>(endpoint, {
+      ...options,
       method: 'POST',
       body: JSON.stringify(body),
     });
   }
 
-  async put<T>(endpoint: string, body: unknown): Promise<ApiResponse<T>> {
+  async put<T>(endpoint: string, body: unknown, options: RequestInit = {}): Promise<ApiResponse<T>> {
     return this.makeRequest<T>(endpoint, {
+      ...options,
       method: 'PUT',
       body: JSON.stringify(body),
     });
   }
 
-  async delete<T>(endpoint: string): Promise<ApiResponse<T>> {
-    return this.makeRequest<T>(endpoint, { method: 'DELETE' });
+  async delete<T>(endpoint: string, options: RequestInit = {}): Promise<ApiResponse<T>> {
+    return this.makeRequest<T>(endpoint, { ...options, method: 'DELETE' });
   }
 }
 

--- a/apps/mobile/src/services/api/favorites.ts
+++ b/apps/mobile/src/services/api/favorites.ts
@@ -20,14 +20,14 @@ class FavoritesApiService {
       return await apiCall(accessToken);
     } catch (error) {
       if ((error as ApiError).status == 401) {
-        if (__DEV__) console.log('Token expired. Attempting to reload authentication.');
+        if (__DEV__) console.log('[favoritesService] Token expired. Attempting to reload authentication.');
 
         const newAuth = await refreshSession();
         if (newAuth?.accessToken)
           return await apiCall(newAuth?.accessToken);
       }
       // If re-authentication wasn't successful
-      if (__DEV__) console.error('Failed to retry the endpoint:', error);
+      if (__DEV__) console.error('[favoritesService] Failed to retry the endpoint:', error);
       throw error;
     }
   }

--- a/apps/mobile/src/services/api/favorites.ts
+++ b/apps/mobile/src/services/api/favorites.ts
@@ -1,0 +1,82 @@
+/**
+ * Service for accessing user favorite-related endpoints (adding, removing, & retrieval)
+ *   A valid accessToken is required - an automatic refresh will be attempted the current is expired
+ */
+import { apiService, ApiError } from './base';
+import API_CONFIG from './config';
+import { AuthResult } from '../../auth/AzureAuth';
+
+class FavoritesApiService {
+  /**
+   * Helper for attempting to refresh tokens & automatically recalling an endpoint in the event of a 401 (unauthorized) error
+   * If a new token is generated, it is passed to the subsequent api call
+   */
+  private async requestWithRetry<T>(
+    apiCall: (token: string) => Promise<T>,
+    accessToken: string,
+    refreshSession: () => Promise<AuthResult | null>
+  ): Promise<T> {
+    try {
+      return await apiCall(accessToken);
+    } catch (error) {
+      if ((error as ApiError).status == 401) {
+        if (__DEV__) console.log('Token expired. Attempting to reload authentication.');
+
+        const newAuth = await refreshSession();
+        if (newAuth?.accessToken)
+          return await apiCall(newAuth?.accessToken);
+      }
+      // If re-authentication wasn't successful
+      if (__DEV__) console.error('Failed to retry the endpoint:', error);
+      throw error;
+    }
+  }
+
+  // Retrieves and returns a list of the user's favorite lots as lotId strings
+  async getAllFavorites(
+    userId: string,
+    accessToken: string,
+    refreshSession: () => Promise<AuthResult | null>
+  ): Promise<string[]> {
+    const id = encodeURIComponent(userId);
+    const endpoint = `${API_CONFIG.ENDPOINTS.USERS}/${id}/favorites`;
+    const favoriteLots = await this.requestWithRetry((token) => apiService.get<string[]>(endpoint, {
+      headers: {'Authorization': `Bearer ${token}`}
+    }), accessToken, refreshSession);
+    return favoriteLots.data;
+  }
+
+  // Adds the specified lot to the users favorites list
+  async addFavorite(
+    userId: string,
+    accessToken: string,
+    lotId: string,
+    refreshSession: () => Promise<AuthResult | null>
+  ): Promise<void> {
+    const id = encodeURIComponent(userId);
+    const endpoint = `${API_CONFIG.ENDPOINTS.USERS}/${id}/favorites/${lotId}`;
+    const response = await this.requestWithRetry((token) => apiService.post<void>(endpoint, {}, {
+      headers: {'Authorization': `Bearer ${token}`}
+    }), accessToken, refreshSession);
+    return response.data;
+  }
+
+  // Removes the specified lot from the users favorites list
+  async removeFavorite(
+    userId: string,
+    accessToken: string,
+    lotId: string,
+    refreshSession: () => Promise<AuthResult | null>
+  ): Promise<void> {
+    const id = encodeURIComponent(userId);
+    const endpoint = `${API_CONFIG.ENDPOINTS.USERS}/${id}/favorites/${lotId}`;
+    const response = await this.requestWithRetry((token) => apiService.delete<void>(endpoint, {
+      headers: {'Authorization': `Bearer ${token}`}
+    }), accessToken, refreshSession);
+    return response.data;
+  }
+}
+
+// Export singleton instance
+export const favoritesApi = new FavoritesApiService();
+export default favoritesApi;

--- a/apps/mobile/src/services/api/favorites.ts
+++ b/apps/mobile/src/services/api/favorites.ts
@@ -19,7 +19,7 @@ class FavoritesApiService {
     try {
       return await apiCall(accessToken);
     } catch (error) {
-      if ((error as ApiError).status == 401) {
+      if ((error as ApiError).status === 401) {
         if (__DEV__) console.log('[favoritesService] Token expired. Attempting to reload authentication.');
 
         const newAuth = await refreshSession();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
       '@react-native/typescript-config':
         specifier: 0.82.1
         version: 0.82.1
+      '@testing-library/react-native':
+        specifier: ^13.3.3
+        version: 13.3.3(jest@29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.9.3)))(react-native@0.82.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.82.1(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.1.1))(react-test-renderer@19.1.1(react@19.1.1))(react@19.1.1)
       '@types/jest':
         specifier: ^29.5.13
         version: 29.5.14
@@ -1605,6 +1608,18 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@testing-library/react-native@13.3.3':
+    resolution: {integrity: sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      jest: '>=29.0.0'
+      react: '>=18.2.0'
+      react-native: '>=0.71'
+      react-test-renderer: '>=18.2.0'
+    peerDependenciesMeta:
+      jest:
+        optional: true
 
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
@@ -3035,7 +3050,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -3154,6 +3169,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -3882,6 +3901,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.1.2:
     resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
     engines: {node: 20 || >=22}
@@ -4424,6 +4447,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
@@ -4736,6 +4763,10 @@ packages:
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -7124,6 +7155,18 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.9.3)))(react-native@0.82.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.82.1(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.1.1))(react-test-renderer@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      jest-matcher-utils: 30.2.0
+      picocolors: 1.1.1
+      pretty-format: 30.2.0
+      react: 19.1.1
+      react-native: 0.82.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.82.1(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.1.1)
+      react-test-renderer: 19.1.1(react@19.1.1)
+      redent: 3.0.0
+    optionalDependencies:
+      jest: 29.7.0(@types/node@22.19.9)(ts-node@10.9.2(@types/node@22.19.9)(typescript@5.9.3))
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -8822,6 +8865,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -9999,6 +10044,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  min-indent@1.0.1: {}
+
   minimatch@10.1.2:
     dependencies:
       '@isaacs/brace-expansion': 5.0.1
@@ -10566,6 +10613,11 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   reflect-metadata@0.2.2: {}
 
   regenerate-unicode-properties@10.2.2:
@@ -10881,6 +10933,10 @@ snapshots:
   strip-bom@4.0.0: {}
 
   strip-final-newline@2.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
 


### PR DESCRIPTION
## Summary
Implements the ability for logged-in users to favorite & unfavorite any given lot. In addition, the navigation FAB of the map screen displays two speed dial options when pressed: "recommended" & "favorites". 

## Additions
`/services/api/favorites.ts`
- Service for invoking favorites-related endpoints (`GET :userId/favorites` for retrievel, `<POST|DELETE> :userId/favorites/:lotId` for addition/removal).
- If user credentials provided for a call are expired, an attempt will be made to refresh the session & the endpoint will be tried again.
- Tests have been created for each of these cases.

`/hooks/useFavorites.ts`
- Hook for utilizing the services provided by the favorites API. Sends & receives user credentials between each end.
- Manages a local copy of the user's favorited lots to ensure that components immediately reflect successful changes.
- Tests have been created for component rendering & to ensure accurate interfacing.

`/components/NavigationSpeedDial.tsx`
- This is composed of the two options that appear after pressing the navigation FAB of the main screen: "recommended" & "favorites".
- Either option will display a navigation modal with the appropriate set of lots ("recommended" currently defaults to all registered lots).

`/components/Modals/NavigationModal.tsx`
- Menu that displays a list of appropriate lots with names & estimated occupancies included.
- When a lot is selected, the user is redirected to the appropriate short-term forecast screen.

## Modifications
`/auth/AzureAuth.tsx`
- Configured an `access_as_user` API via Microsoft Entra and added it to the scope config.
   - This is needed for users to be able to make API calls using their access tokens.
- `userId` is now an attribute of `AuthResult`, as it acts as the identifier of the current user.

`/context/AuthContext.tsx`
- Implemented & exported `refreshSession` so that session refreshing can be performed by other processes, e.g. when attempting to access user endpoints.

`/screens/MapScreen.tsx`
- Added the navigation modal & the values required for it to be functional (e.g. the lots to display).
- The navigation FAB is now passed to & wrapped within the navigation speed dial options, as the two are loosely coupled.

`/screens/ShortTermForecastScreen.tsx`
- Implemented a button for toggling the favorited status of the current lot. Changing its status reflects immediately both locally  & in the backend.
- An alert will be displayed if the backend cannot be communicated with, and any local changes are nullified.

`/services/api/base.ts`
- Added an optional `options` parameter to `get`, `post`, `put`, and `delete`. This is necessary in order to pass authorization/bearer information to any of these requests when needed, e.g. for invoking user endpoints that require an access token.

## Screenshots
<img width="383" height="377" alt="image" src="https://github.com/user-attachments/assets/3438fee6-1161-4392-96b6-7504ac97e4f6" />
<img width="187" height="217" alt="image" src="https://github.com/user-attachments/assets/c15daffa-5f10-47b8-a9b6-b16502cb0f5a" />
<img width="388" height="817" alt="image" src="https://github.com/user-attachments/assets/4741e5fa-3a41-4be7-9586-859a5619ef27" />