### PR TITLE
fix: cross-platform Windows compatibility and Android icon rendering

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -121,4 +121,7 @@ dependencies {
     }
 }
 
+project.ext.vectoricons = [
+    iconFontsDir: "../../../../node_modules/react-native-vector-icons/Fonts"
+]
 apply from: file("../../../../node_modules/react-native-vector-icons/fonts.gradle")

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "prettier . --check",
     "format:fix": "prettier . --write",
     "prepare": "husky || true",
-    "postinstall": "node -e \"if (process.env.SKIP_LOCAL_INFRA !== '1') require('child_process').execSync('./scripts/start-local.sh', {stdio: 'inherit'})\" || true",
+    "postinstall": "node -e \"if (process.env.SKIP_LOCAL_INFRA !== '1') require('child_process').execSync('bash scripts/start-local.sh', {stdio: 'inherit'})\" || true",
     "test": "turbo run test",
     "db:setup": "pnpm --filter @sharkpark/backend exec prisma migrate dev",
     "db:deploy": "pnpm --filter @sharkpark/backend exec prisma migrate deploy",


### PR DESCRIPTION
# Fix cross-platform Windows compatibility

## Summary

Fixes two issues affecting Windows and Android development. The postinstall script failed on Windows because `cmd.exe` can't execute `.sh` files directly, and Android icons weren't rendering because the vector icons font path wasn't configured for the monorepo structure.

## Problem
1. **Shell script invocation**: The postinstall command uses `./scripts/start-local.sh` inside `execSync()`. On Windows, Node's `execSync` uses `cmd.exe` by default, which cannot execute a `.sh` file via the shebang line. This causes pnpm to report the install as "Failed."

2. **Android vector icons not loading**: The `build.gradle` for the mobile app was missing the `project.ext.vectoricons` configuration block that tells the `react-native-vector-icons` Gradle script where to find the font files in `node_modules`. Without this, icon fonts aren't copied into Android's assets.

## Changes

- **`package.json`**: Changed the postinstall command from `./scripts/start-local.sh` to `bash scripts/start-local.sh`, explicitly invoking bash so the script runs correctly on both Windows (Git Bash) and Unix systems.

- **`apps/mobile/android/app/build.gradle`**: Added the `project.ext.vectoricons` block pointing `iconFontsDir` to the correct `node_modules` path, so `fonts.gradle` can locate and copy icon font files into the Android app assets.

