### PR TITLE
feat: penetration rate estimation, lot amenities, polling & expanded test coverage

### DIFF
--- a/apps/backend/prisma/migrations/20260308045807_add_penetration_estimation/migration.sql
+++ b/apps/backend/prisma/migrations/20260308045807_add_penetration_estimation/migration.sql
@@ -1,0 +1,27 @@
+-- AlterTable
+ALTER TABLE "academic_calendar" ADD COLUMN     "expected_commuters" INTEGER NOT NULL DEFAULT 35000;
+
+-- AlterTable
+ALTER TABLE "occupancy_snapshots" ADD COLUMN     "estimated_occupancy" INTEGER,
+ADD COLUMN     "penetration_rate_used" DOUBLE PRECISION;
+
+-- CreateTable
+CREATE TABLE "campus_activity_baselines" (
+    "id" TEXT NOT NULL,
+    "school_id" TEXT NOT NULL,
+    "period_type" TEXT NOT NULL,
+    "day_of_week" INTEGER NOT NULL,
+    "hour_of_day" INTEGER NOT NULL,
+    "avg_devices" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "peak_devices" INTEGER NOT NULL DEFAULT 0,
+    "sample_count" INTEGER NOT NULL DEFAULT 0,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "campus_activity_baselines_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "campus_activity_baselines_school_id_period_type_day_of_week_key" ON "campus_activity_baselines"("school_id", "period_type", "day_of_week", "hour_of_day");
+
+-- AddForeignKey
+ALTER TABLE "campus_activity_baselines" ADD CONSTRAINT "campus_activity_baselines_school_id_fkey" FOREIGN KEY ("school_id") REFERENCES "schools"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/backend/prisma/migrations/20260308200000_remove_calendar_tables/migration.sql
+++ b/apps/backend/prisma/migrations/20260308200000_remove_calendar_tables/migration.sql
@@ -1,0 +1,17 @@
+-- DropForeignKey
+ALTER TABLE "academic_calendar" DROP CONSTRAINT IF EXISTS "academic_calendar_school_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "campus_closures" DROP CONSTRAINT IF EXISTS "campus_closures_school_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "campus_activity_baselines" DROP CONSTRAINT IF EXISTS "campus_activity_baselines_school_id_fkey";
+
+-- DropTable
+DROP TABLE IF EXISTS "academic_calendar";
+
+-- DropTable
+DROP TABLE IF EXISTS "campus_closures";
+
+-- DropTable
+DROP TABLE IF EXISTS "campus_activity_baselines";

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -22,9 +22,6 @@ model School {
   lots             Lot[]
   users            User[]
   campus_events    CampusEvent[]
-  academic_periods AcademicCalendar[]
-  campus_closures  CampusClosure[]
-  activity_baselines CampusActivityBaseline[]
   weather          Weather[]
 
   @@map("schools")
@@ -145,9 +142,9 @@ model OccupancySnapshot {
   estimated_occupancy    Int?     // Scaled-up occupancy estimate
   penetration_rate_used  Float?   // Effective penetration rate at snapshot time
 
-  // ML feature columns
-  semester          String?         // "FALL", "SPRING", "SUMMER", "SESSION", "BREAK"
-  academic_period   String?         // "EARLY", "REGULAR", "MIDTERMS", "LATE", "DEAD_WEEK", "FINALS", "BREAK"
+  // ML feature columns (populated at write time by academic-calendar.ts)
+  semester          String?         // "fall", "spring", "summer", "session", "break"
+  academic_period   String?         // "early", "regular", "midterms", "late", "dead_week", "finals", "break"
   week_of_semester  Int?
   is_campus_open    Boolean         @default(true)
 
@@ -202,48 +199,6 @@ model EventImpact {
 
   @@unique([event_id, lot_id])
   @@map("event_impacts")
-}
-
-model AcademicCalendar {
-  id                  String   @id @default(cuid())
-  school_id           String
-  period_name         String   // "Fall 2025", "Spring 2026"
-  period_type         String   // "FALL", "SPRING", "SUMMER", "SESSION", "BREAK"
-  start_date          DateTime
-  end_date            DateTime
-  expected_commuters  Int      @default(35000) // Estimated daily commuters for this period
-
-  school School @relation(fields: [school_id], references: [id])
-
-  @@map("academic_calendar")
-}
-
-model CampusClosure {
-  id        String   @id @default(cuid())
-  school_id String
-  reason    String
-  date      DateTime
-
-  school School @relation(fields: [school_id], references: [id])
-
-  @@map("campus_closures")
-}
-
-model CampusActivityBaseline {
-  id           String   @id @default(cuid())
-  school_id    String
-  period_type  String   // "FALL", "SPRING", "SUMMER", "SESSION", "BREAK"
-  day_of_week  Int      // 0 = Sunday, 6 = Saturday
-  hour_of_day  Int      // 0–23
-  avg_devices  Float    @default(0) // Rolling average of unique devices seen
-  peak_devices Int      @default(0) // Max ever seen in this slot
-  sample_count Int      @default(0) // Number of observations averaged
-  updated_at   DateTime @updatedAt
-
-  school School @relation(fields: [school_id], references: [id])
-
-  @@unique([school_id, period_type, day_of_week, hour_of_day])
-  @@map("campus_activity_baselines")
 }
 
 model Weather {

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -24,6 +24,7 @@ model School {
   campus_events    CampusEvent[]
   academic_periods AcademicCalendar[]
   campus_closures  CampusClosure[]
+  activity_baselines CampusActivityBaseline[]
   weather          Weather[]
 
   @@map("schools")
@@ -140,6 +141,10 @@ model OccupancySnapshot {
   reliability_score Float?
   is_cold_start     Boolean?
 
+  // Penetration rate estimation columns
+  estimated_occupancy    Int?     // Scaled-up occupancy estimate
+  penetration_rate_used  Float?   // Effective penetration rate at snapshot time
+
   // ML feature columns
   semester          String?         // "FALL", "SPRING", "SUMMER", "SESSION", "BREAK"
   academic_period   String?         // "EARLY", "REGULAR", "MIDTERMS", "LATE", "DEAD_WEEK", "FINALS", "BREAK"
@@ -200,12 +205,13 @@ model EventImpact {
 }
 
 model AcademicCalendar {
-  id          String   @id @default(cuid())
-  school_id   String
-  period_name String   // "Fall 2025", "Spring 2026"
-  period_type String   // "FALL", "SPRING", "SUMMER", "SESSION", "BREAK"
-  start_date  DateTime
-  end_date    DateTime
+  id                  String   @id @default(cuid())
+  school_id           String
+  period_name         String   // "Fall 2025", "Spring 2026"
+  period_type         String   // "FALL", "SPRING", "SUMMER", "SESSION", "BREAK"
+  start_date          DateTime
+  end_date            DateTime
+  expected_commuters  Int      @default(35000) // Estimated daily commuters for this period
 
   school School @relation(fields: [school_id], references: [id])
 
@@ -221,6 +227,23 @@ model CampusClosure {
   school School @relation(fields: [school_id], references: [id])
 
   @@map("campus_closures")
+}
+
+model CampusActivityBaseline {
+  id           String   @id @default(cuid())
+  school_id    String
+  period_type  String   // "FALL", "SPRING", "SUMMER", "SESSION", "BREAK"
+  day_of_week  Int      // 0 = Sunday, 6 = Saturday
+  hour_of_day  Int      // 0–23
+  avg_devices  Float    @default(0) // Rolling average of unique devices seen
+  peak_devices Int      @default(0) // Max ever seen in this slot
+  sample_count Int      @default(0) // Number of observations averaged
+  updated_at   DateTime @updatedAt
+
+  school School @relation(fields: [school_id], references: [id])
+
+  @@unique([school_id, period_type, day_of_week, hour_of_day])
+  @@map("campus_activity_baselines")
 }
 
 model Weather {

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -607,9 +607,6 @@ async function main() {
   await prisma.predictionLongTerm.deleteMany();
   await prisma.campusEvent.deleteMany();
   await prisma.weather.deleteMany();
-  await prisma.academicCalendar.deleteMany();
-  await prisma.campusClosure.deleteMany();
-  await prisma.campusActivityBaseline.deleteMany();
   await prisma.user.deleteMany();
   await prisma.lot.deleteMany();
   await prisma.school.deleteMany();
@@ -757,65 +754,6 @@ async function main() {
   });
   console.log('[seed] Seeded weather data\n');
 
-  // 6b. Seed Academic Calendar
-  console.log('[seed] Seeding academic calendar...');
-  const academicPeriods = [
-    // Fall 2025 (historical — classes Aug 25 through finals week Dec 18)
-    { name: 'Fall 2025',              type: 'FALL',    start: '2025-08-25', end: '2025-12-18', commuters: 35000 },
-    // Winter break — campus mostly closed, minimal staff
-    { name: 'Winter Break 2025-26',   type: 'BREAK',   start: '2025-12-19', end: '2026-01-19', commuters: 1500 },
-    // Winter intersession — smaller enrollment, campus open
-    { name: 'Winter Session 2026',    type: 'SESSION', start: '2026-01-05', end: '2026-01-16', commuters: 3000 },
-    // Spring 2026 — classes start Jan 20 (Tue after MLK Day)
-    { name: 'Spring 2026',            type: 'SPRING',  start: '2026-01-20', end: '2026-05-22', commuters: 34000 },
-    // Spring break — no classes, campus open for staff/employees only
-    { name: 'Spring Break 2026',      type: 'BREAK',   start: '2026-03-30', end: '2026-04-05', commuters: 3600 },
-    // Summer 2026 — 12-week session starts May 26
-    { name: 'Summer 2026',            type: 'SUMMER',  start: '2026-05-26', end: '2026-08-14', commuters: 8000 },
-    { name: 'Fall 2026',              type: 'FALL',    start: '2026-08-24', end: '2026-12-18', commuters: 35000 },
-    { name: 'Winter Break 2026-27',   type: 'BREAK',   start: '2026-12-19', end: '2027-01-18', commuters: 1500 },
-  ];
-  for (const period of academicPeriods) {
-    await prisma.academicCalendar.create({
-      data: {
-        school_id: school.id,
-        period_name: period.name,
-        period_type: period.type,
-        start_date: new Date(period.start),
-        end_date: new Date(period.end),
-        expected_commuters: period.commuters,
-      },
-    });
-  }
-  console.log(`[seed] Seeded ${academicPeriods.length} academic periods\n`);
-
-  // 6c. Seed Campus Closures (2025-2026)
-  console.log('[seed] Seeding campus closures...');
-  const campusClosures = [
-    // Spring break is NOT a closure — campus stays open for staff/employees;
-    // handled via the 'Spring Break 2026' BREAK period with reduced commuters.
-    // Presidents' Day is NOT observed as a campus closure at CSULB.
-    { date: '2026-01-19', reason: 'Martin Luther King Jr. Day' },
-    { date: '2026-03-31', reason: 'Cesar Chavez Day' },
-    { date: '2026-05-25', reason: 'Memorial Day' },
-    { date: '2026-06-19', reason: 'Juneteenth' },
-    { date: '2026-07-03', reason: 'Independence Day (observed)' },
-    { date: '2026-09-07', reason: 'Labor Day' },
-    { date: '2026-11-11', reason: 'Veterans Day' },
-    { date: '2026-11-26', reason: 'Thanksgiving' },
-    { date: '2026-11-27', reason: 'Thanksgiving Friday' },
-  ];
-  for (const closure of campusClosures) {
-    await prisma.campusClosure.create({
-      data: {
-        school_id: school.id,
-        reason: closure.reason,
-        date: new Date(closure.date),
-      },
-    });
-  }
-  console.log(`[seed] Seeded ${campusClosures.length} campus closures\n`);
-
   // 7. Seed Historical Occupancy Snapshots (7 days, every 15 min during operating hours)
   console.log('[seed] Seeding historical occupancy snapshots...');
   const sampleLotIds = ['G1', 'G2', 'G4', 'G7', 'G9'];
@@ -940,8 +878,6 @@ async function main() {
     favorites: await prisma.userFavorite.count(),
     events: await prisma.campusEvent.count(),
     impacts: await prisma.eventImpact.count(),
-    academicPeriods: await prisma.academicCalendar.count(),
-    campusClosures: await prisma.campusClosure.count(),
     weather: await prisma.weather.count(),
     snapshots: await prisma.occupancySnapshot.count(),
     occEvents: await prisma.occupancyEvent.count(),

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -81,7 +81,7 @@ const parkingLots: LotSeed[] = [
   // ===== STUDENT LOTS (G LOTS) =====
   {
     lot_id: 'G1', lot_name: 'Lot G1', display_name: 'Lot G1 - East Campus', lot_number: 'G1',
-    lot_type: LotType.STUDENT, capacity: 231, current_occupancy: 182,
+    lot_type: LotType.STUDENT, capacity: 231, current_occupancy: 27,
     location_description: 'East Campus - Near Japanese Garden',
     building_proximity: ['ECS', 'Japanese Garden', 'East Walkway'],
     center_lat: 33.7838, center_lng: -118.1089, geofence_radius: 50,
@@ -95,7 +95,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'G2', lot_name: 'Lot G2', display_name: 'Lot G2 - Walter Pyramid', lot_number: 'G2',
-    lot_type: LotType.STUDENT, capacity: 419, current_occupancy: 307,
+    lot_type: LotType.STUDENT, capacity: 419, current_occupancy: 55,
     location_description: 'East Campus - Walter Pyramid',
     building_proximity: ['Walter Pyramid', 'Athletics', 'Tennis Courts'],
     center_lat: 33.7825, center_lng: -118.1098, geofence_radius: 70,
@@ -110,7 +110,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'G3', lot_name: 'Lot G3', display_name: 'Lot G3 - East Campus', lot_number: 'G3',
-    lot_type: LotType.STUDENT, capacity: 230, current_occupancy: 176,
+    lot_type: LotType.STUDENT, capacity: 230, current_occupancy: 21,
     location_description: 'East Campus',
     building_proximity: ['East Campus Buildings'],
     center_lat: 33.7830, center_lng: -118.1075, geofence_radius: 60,
@@ -124,7 +124,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'G4', lot_name: 'Lot G4', display_name: 'Lot G4 - Central Campus', lot_number: 'G4',
-    lot_type: LotType.STUDENT, capacity: 463, current_occupancy: 331,
+    lot_type: LotType.STUDENT, capacity: 463, current_occupancy: 66,
     location_description: 'Central Campus',
     building_proximity: ['USU', 'Library', 'Admin Building'],
     center_lat: 33.7819, center_lng: -118.1134, geofence_radius: 80,
@@ -139,7 +139,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'G5', lot_name: 'Lot G5', display_name: 'Lot G5 - West Campus', lot_number: 'G5',
-    lot_type: LotType.STUDENT, capacity: 120, current_occupancy: 82,
+    lot_type: LotType.STUDENT, capacity: 120, current_occupancy: 8,
     location_description: 'West Campus',
     building_proximity: ['West Campus Buildings'],
     center_lat: 33.7805, center_lng: -118.1165, geofence_radius: 55,
@@ -153,7 +153,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'G7', lot_name: 'Lot G7', display_name: 'Lot G7 - Engineering', lot_number: 'G7',
-    lot_type: LotType.STUDENT, capacity: 751, current_occupancy: 613,
+    lot_type: LotType.STUDENT, capacity: 751, current_occupancy: 98,
     location_description: 'East Campus - Engineering Complex',
     building_proximity: ['Engineering', 'Computer Science', 'CEAC'],
     center_lat: 33.7842, center_lng: -118.1115, geofence_radius: 65,
@@ -168,7 +168,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'G8', lot_name: 'Lot G8', display_name: 'Lot G8 - Student Health', lot_number: 'G8',
-    lot_type: LotType.STUDENT, capacity: 720, current_occupancy: 548,
+    lot_type: LotType.STUDENT, capacity: 720, current_occupancy: 77,
     location_description: 'West Campus - Student Health Center',
     building_proximity: ['Student Health', 'Recreation Center'],
     center_lat: 33.7812, center_lng: -118.1145, geofence_radius: 60,
@@ -182,7 +182,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'G9', lot_name: 'Lot G9', display_name: 'Lot G9 - Library', lot_number: 'G9',
-    lot_type: LotType.STUDENT, capacity: 405, current_occupancy: 347,
+    lot_type: LotType.STUDENT, capacity: 405, current_occupancy: 66,
     location_description: 'West Campus - University Library',
     building_proximity: ['Library', 'Academic Buildings'],
     center_lat: 33.7817, center_lng: -118.1152, geofence_radius: 70,
@@ -197,7 +197,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'G10', lot_name: 'Lot G10', display_name: 'Lot G10 - South Campus', lot_number: 'G10',
-    lot_type: LotType.STUDENT, capacity: 19, current_occupancy: 15,
+    lot_type: LotType.STUDENT, capacity: 19, current_occupancy: 2,
     location_description: 'South Campus', building_proximity: ['South Campus Buildings'],
     center_lat: 33.7798, center_lng: -118.1120, geofence_radius: 55,
     permit_types: ['Gold', 'Green'], daily_permit_allowed: false,
@@ -210,7 +210,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'G11', lot_name: 'Lot G11', display_name: 'Lot G11 - Palo Verde', lot_number: 'G11',
-    lot_type: LotType.STUDENT, capacity: 319, current_occupancy: 229,
+    lot_type: LotType.STUDENT, capacity: 319, current_occupancy: 21,
     location_description: 'East Campus - Palo Verde',
     building_proximity: ['Palo Verde', 'Student Housing'],
     center_lat: 33.7845, center_lng: -118.1070, geofence_radius: 50,
@@ -224,7 +224,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'G12', lot_name: 'Lot G12', display_name: 'Lot G12 - North Campus', lot_number: 'G12',
-    lot_type: LotType.STUDENT, capacity: 628, current_occupancy: 455,
+    lot_type: LotType.STUDENT, capacity: 628, current_occupancy: 36,
     location_description: 'North Campus',
     building_proximity: ['North Campus Buildings'],
     center_lat: 33.7855, center_lng: -118.1130, geofence_radius: 45,
@@ -238,7 +238,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'G14', lot_name: 'Lot G14', display_name: 'Lot G14 - Beachside', lot_number: 'G14',
-    lot_type: LotType.STUDENT, capacity: 262, current_occupancy: 197,
+    lot_type: LotType.STUDENT, capacity: 262, current_occupancy: 26,
     location_description: 'West Campus - Near PCH',
     building_proximity: ['Beach Access', 'West Gate'],
     center_lat: 33.7790, center_lng: -118.1175, geofence_radius: 60,
@@ -254,7 +254,7 @@ const parkingLots: LotSeed[] = [
   // ===== EMPLOYEE LOTS =====
   {
     lot_id: 'E1', lot_name: 'Lot E1', display_name: 'Lot E1 - Faculty/Staff', lot_number: 'E1',
-    lot_type: LotType.EMPLOYEE, capacity: 440, current_occupancy: 359,
+    lot_type: LotType.EMPLOYEE, capacity: 440, current_occupancy: 79,
     location_description: 'Central Campus - Admin Area',
     building_proximity: ['Administration', 'Faculty Offices'],
     center_lat: 33.7822, center_lng: -118.1128, geofence_radius: 40,
@@ -268,7 +268,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'E2', lot_name: 'Lot E2', display_name: 'Lot E2 - Faculty/Staff', lot_number: 'E2',
-    lot_type: LotType.EMPLOYEE, capacity: 269, current_occupancy: 221,
+    lot_type: LotType.EMPLOYEE, capacity: 269, current_occupancy: 55,
     location_description: 'East Campus - Faculty',
     building_proximity: ['Engineering Faculty', 'Science Faculty'],
     center_lat: 33.7835, center_lng: -118.1105, geofence_radius: 35,
@@ -282,7 +282,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'E3', lot_name: 'Lot E3', display_name: 'Lot E3 - Faculty/Staff', lot_number: 'E3',
-    lot_type: LotType.EMPLOYEE, capacity: 65, current_occupancy: 49,
+    lot_type: LotType.EMPLOYEE, capacity: 65, current_occupancy: 10,
     location_description: 'West Campus - Faculty',
     building_proximity: ['Liberal Arts', 'Education'],
     center_lat: 33.7810, center_lng: -118.1155, geofence_radius: 45,
@@ -296,7 +296,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'E4', lot_name: 'Lot E4', display_name: 'Lot E4 - Faculty/Staff', lot_number: 'E4',
-    lot_type: LotType.EMPLOYEE, capacity: 81, current_occupancy: 67,
+    lot_type: LotType.EMPLOYEE, capacity: 81, current_occupancy: 20,
     location_description: 'Central Campus - Faculty',
     building_proximity: ['Admin Building', 'President Office'],
     center_lat: 33.7820, center_lng: -118.1140, geofence_radius: 60,
@@ -311,7 +311,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'E5', lot_name: 'Lot E5', display_name: 'Lot E5 - Faculty/Staff', lot_number: 'E5',
-    lot_type: LotType.EMPLOYEE, capacity: 66, current_occupancy: 54,
+    lot_type: LotType.EMPLOYEE, capacity: 66, current_occupancy: 15,
     location_description: 'North Campus - Faculty',
     building_proximity: ['Science Buildings', 'Research Labs'],
     center_lat: 33.7850, center_lng: -118.1125, geofence_radius: 30,
@@ -325,7 +325,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'E6', lot_name: 'Lot E6', display_name: 'Lot E6 - Faculty/Staff', lot_number: 'E6',
-    lot_type: LotType.EMPLOYEE, capacity: 240, current_occupancy: 194,
+    lot_type: LotType.EMPLOYEE, capacity: 240, current_occupancy: 35,
     location_description: 'Central Campus - Faculty',
     building_proximity: ['Music', 'Theatre Arts'],
     center_lat: 33.7815, center_lng: -118.1138, geofence_radius: 40,
@@ -339,7 +339,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'E7', lot_name: 'Lot E7', display_name: 'Lot E7 - Faculty/Staff', lot_number: 'E7',
-    lot_type: LotType.EMPLOYEE, capacity: 91, current_occupancy: 70,
+    lot_type: LotType.EMPLOYEE, capacity: 91, current_occupancy: 11,
     location_description: 'South Campus - Faculty',
     building_proximity: ['South Campus Faculty Offices'],
     center_lat: 33.7795, center_lng: -118.1135, geofence_radius: 30,
@@ -354,7 +354,7 @@ const parkingLots: LotSeed[] = [
   // ===== ADDITIONAL STUDENT LOTS =====
   {
     lot_id: 'G6', lot_name: 'Lot G6', display_name: 'Lot G6 - South Campus', lot_number: 'G6',
-    lot_type: LotType.STUDENT, capacity: 793, current_occupancy: 599,
+    lot_type: LotType.STUDENT, capacity: 793, current_occupancy: 66,
     location_description: 'South Campus',
     building_proximity: ['Kinesiology', 'Gymnasium'],
     center_lat: 33.7800, center_lng: -118.1110, geofence_radius: 55,
@@ -368,7 +368,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'G13', lot_name: 'Lot G13', display_name: 'Lot G13 - Upper Campus', lot_number: 'G13',
-    lot_type: LotType.STUDENT, capacity: 304, current_occupancy: 226,
+    lot_type: LotType.STUDENT, capacity: 304, current_occupancy: 18,
     location_description: 'Upper Campus',
     building_proximity: ['Upper Campus Buildings'],
     center_lat: 33.7860, center_lng: -118.1100, geofence_radius: 50,
@@ -382,7 +382,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'E8', lot_name: 'Lot E8', display_name: 'Lot E8 - Faculty/Staff', lot_number: 'E8',
-    lot_type: LotType.EMPLOYEE, capacity: 380, current_occupancy: 285,
+    lot_type: LotType.EMPLOYEE, capacity: 380, current_occupancy: 57,
     location_description: 'North Campus - Faculty',
     building_proximity: ['Research Park'],
     center_lat: 33.7858, center_lng: -118.1115, geofence_radius: 25,
@@ -396,7 +396,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'E9', lot_name: 'Lot E9', display_name: 'Lot E9 - Faculty/Staff', lot_number: 'E9',
-    lot_type: LotType.EMPLOYEE, capacity: 167, current_occupancy: 138,
+    lot_type: LotType.EMPLOYEE, capacity: 167, current_occupancy: 4,
     location_description: 'North Campus - Faculty',
     building_proximity: ['Faculty Offices'],
     center_lat: 33.7841, center_lng: -118.1153, geofence_radius: 32,
@@ -410,7 +410,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'E10', lot_name: 'Lot E10', display_name: 'Lot E10 - Faculty/Staff', lot_number: 'E10',
-    lot_type: LotType.EMPLOYEE, capacity: 183, current_occupancy: 118,
+    lot_type: LotType.EMPLOYEE, capacity: 183, current_occupancy: 5,
     location_description: 'South Campus - Faculty',
     building_proximity: ['Faculty Offices'],
     center_lat: 33.7825, center_lng: -118.1135, geofence_radius: 35,
@@ -424,7 +424,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'E11', lot_name: 'Lot E11', display_name: 'Lot E11 - Faculty/Staff', lot_number: 'E11',
-    lot_type: LotType.EMPLOYEE, capacity: 98, current_occupancy: 80,
+    lot_type: LotType.EMPLOYEE, capacity: 98, current_occupancy: 4,
     location_description: 'Central Campus - Faculty',
     building_proximity: ['Faculty Offices', 'Admin Building'],
     center_lat: 33.7835, center_lng: -118.1140, geofence_radius: 40,
@@ -439,7 +439,7 @@ const parkingLots: LotSeed[] = [
   // ===== NAMED LOTS =====
   {
     lot_id: 'PVN', lot_name: 'Palo Verde North', display_name: 'Palo Verde North - North Campus', lot_number: 'PVN',
-    lot_type: LotType.STUDENT, capacity: 1400, current_occupancy: 910,
+    lot_type: LotType.STUDENT, capacity: 1400, current_occupancy: 91,
     location_description: 'North Campus - Palo Verde Structure',
     building_proximity: ['Palo Verde North', 'Recreation Center'],
     center_lat: 33.7850, center_lng: -118.1170, geofence_radius: 50,
@@ -454,7 +454,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'PVS', lot_name: 'Palo Verde South', display_name: 'Palo Verde South - South Campus', lot_number: 'PVS',
-    lot_type: LotType.STUDENT, capacity: 1410, current_occupancy: 914,
+    lot_type: LotType.STUDENT, capacity: 1410, current_occupancy: 82,
     location_description: 'South Campus - Palo Verde Structure',
     building_proximity: ['Palo Verde South', 'Recreation Center'],
     center_lat: 33.7820, center_lng: -118.1175, geofence_radius: 48,
@@ -469,7 +469,7 @@ const parkingLots: LotSeed[] = [
   },
   {
     lot_id: 'PYR', lot_name: 'Pyramid Parking Structure', display_name: 'Pyramid Structure - Event Parking', lot_number: 'PYR',
-    lot_type: LotType.STUDENT, capacity: 3000, current_occupancy: 2373,
+    lot_type: LotType.STUDENT, capacity: 3000, current_occupancy: 380,
     location_description: 'East Campus - Near Walter Pyramid',
     building_proximity: ['Walter Pyramid', 'Athletics', 'Sports Facilities'],
     center_lat: 33.7825, center_lng: -118.1095, geofence_radius: 65,
@@ -609,6 +609,7 @@ async function main() {
   await prisma.weather.deleteMany();
   await prisma.academicCalendar.deleteMany();
   await prisma.campusClosure.deleteMany();
+  await prisma.campusActivityBaseline.deleteMany();
   await prisma.user.deleteMany();
   await prisma.lot.deleteMany();
   await prisma.school.deleteMany();
@@ -756,6 +757,65 @@ async function main() {
   });
   console.log('[seed] Seeded weather data\n');
 
+  // 6b. Seed Academic Calendar
+  console.log('[seed] Seeding academic calendar...');
+  const academicPeriods = [
+    // Fall 2025 (historical — classes Aug 25 through finals week Dec 18)
+    { name: 'Fall 2025',              type: 'FALL',    start: '2025-08-25', end: '2025-12-18', commuters: 35000 },
+    // Winter break — campus mostly closed, minimal staff
+    { name: 'Winter Break 2025-26',   type: 'BREAK',   start: '2025-12-19', end: '2026-01-19', commuters: 1500 },
+    // Winter intersession — smaller enrollment, campus open
+    { name: 'Winter Session 2026',    type: 'SESSION', start: '2026-01-05', end: '2026-01-16', commuters: 3000 },
+    // Spring 2026 — classes start Jan 20 (Tue after MLK Day)
+    { name: 'Spring 2026',            type: 'SPRING',  start: '2026-01-20', end: '2026-05-22', commuters: 34000 },
+    // Spring break — no classes, campus open for staff/employees only
+    { name: 'Spring Break 2026',      type: 'BREAK',   start: '2026-03-30', end: '2026-04-05', commuters: 3600 },
+    // Summer 2026 — 12-week session starts May 26
+    { name: 'Summer 2026',            type: 'SUMMER',  start: '2026-05-26', end: '2026-08-14', commuters: 8000 },
+    { name: 'Fall 2026',              type: 'FALL',    start: '2026-08-24', end: '2026-12-18', commuters: 35000 },
+    { name: 'Winter Break 2026-27',   type: 'BREAK',   start: '2026-12-19', end: '2027-01-18', commuters: 1500 },
+  ];
+  for (const period of academicPeriods) {
+    await prisma.academicCalendar.create({
+      data: {
+        school_id: school.id,
+        period_name: period.name,
+        period_type: period.type,
+        start_date: new Date(period.start),
+        end_date: new Date(period.end),
+        expected_commuters: period.commuters,
+      },
+    });
+  }
+  console.log(`[seed] Seeded ${academicPeriods.length} academic periods\n`);
+
+  // 6c. Seed Campus Closures (2025-2026)
+  console.log('[seed] Seeding campus closures...');
+  const campusClosures = [
+    // Spring break is NOT a closure — campus stays open for staff/employees;
+    // handled via the 'Spring Break 2026' BREAK period with reduced commuters.
+    // Presidents' Day is NOT observed as a campus closure at CSULB.
+    { date: '2026-01-19', reason: 'Martin Luther King Jr. Day' },
+    { date: '2026-03-31', reason: 'Cesar Chavez Day' },
+    { date: '2026-05-25', reason: 'Memorial Day' },
+    { date: '2026-06-19', reason: 'Juneteenth' },
+    { date: '2026-07-03', reason: 'Independence Day (observed)' },
+    { date: '2026-09-07', reason: 'Labor Day' },
+    { date: '2026-11-11', reason: 'Veterans Day' },
+    { date: '2026-11-26', reason: 'Thanksgiving' },
+    { date: '2026-11-27', reason: 'Thanksgiving Friday' },
+  ];
+  for (const closure of campusClosures) {
+    await prisma.campusClosure.create({
+      data: {
+        school_id: school.id,
+        reason: closure.reason,
+        date: new Date(closure.date),
+      },
+    });
+  }
+  console.log(`[seed] Seeded ${campusClosures.length} campus closures\n`);
+
   // 7. Seed Historical Occupancy Snapshots (7 days, every 15 min during operating hours)
   console.log('[seed] Seeding historical occupancy snapshots...');
   const sampleLotIds = ['G1', 'G2', 'G4', 'G7', 'G9'];
@@ -806,70 +866,70 @@ async function main() {
   }
   console.log(`[seed] Seeded ${snapshotRows.length} historical occupancy snapshots\n`);
 
-  // 8. Seed Occupancy Events (last 24 hours)
+  // 8. Seed Occupancy Events (last 2 hours, all lots)
+  // Generate ~1,500 unique device hashes so countCampusDevices returns a
+  // realistic number and the scaling cap doesn't bottleneck at 2×.
+  console.log('[seed] Generating unique device hashes...');
+  const TOTAL_CAMPUS_DEVICES = 1500;
+  const allDeviceHashes: string[] = [];
+  for (let i = 0; i < TOTAL_CAMPUS_DEVICES; i++) {
+    // Deterministic hex hashes: pad index and repeat to 64 chars
+    const hex = i.toString(16).padStart(4, '0');
+    allDeviceHashes.push(hex.repeat(16));
+  }
+
   console.log('[seed] Seeding occupancy events...');
-  const sampleDeviceHashes = [
-    '5de210df8a7e4b2c9f1a3d5e7b9c1d3f5a7b9c1d3e5f7a9b1c3d5e7f9a1b3c5d',
-    '7f3a1b5c9d2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2b4c6d8e0f2a4b6c8d0e2f4',
-    '9e5c3a1d7f2b8e4a0c6d2f8a4b0e6c2d8f4a0b6c2e8d4f0a6b2c8e4d0f6a2b8',
-    'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2',
-    'b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4',
-  ];
   const eventRows: {
     lot_id: string; event_type: EventType; device_hash: string; timestamp: Date;
   }[] = [];
-
-  for (let hourOffset = 0; hourOffset < 24; hourOffset++) {
-    const eventTime = new Date(now.getTime() - hourOffset * 60 * 60 * 1000);
-    const hour = eventTime.getHours();
-    if (hour < 6 || hour >= 22) continue;
-
-    for (const lotId of sampleLotIds) {
-      const lotDbId = lotMap.get(lotId);
-      if (!lotDbId) continue;
-
-      const numEvents = Math.floor(Math.random() * 4) + 2;
-      for (let i = 0; i < numEvents; i++) {
-        const deviceHash = sampleDeviceHashes[Math.floor(Math.random() * sampleDeviceHashes.length)];
-        const eventType = Math.random() > 0.5 ? EventType.ENTER : EventType.EXIT;
-        const minuteOffset = Math.floor(Math.random() * 60);
-        const eventTimestamp = new Date(eventTime.getTime() - minuteOffset * 60 * 1000);
-
-        eventRows.push({
-          lot_id: lotDbId,
-          event_type: eventType,
-          device_hash: deviceHash,
-          timestamp: eventTimestamp,
-        });
-      }
-    }
-  }
-
-  // Batch insert
-  await prisma.occupancyEvent.createMany({ data: eventRows });
-  console.log(`[seed] Seeded ${eventRows.length} occupancy events\n`);
-
-  // 9. Seed Device State (deduplication records)
-  console.log('[seed] Seeding device state records...');
   const deviceStateRows: {
     device_hash: string; lot_id: string; last_event_type: EventType; updated_at: Date;
   }[] = [];
 
-  for (const deviceHash of sampleDeviceHashes) {
-    for (const lotId of sampleLotIds.slice(0, 2)) {
-      const lotDbId = lotMap.get(lotId);
-      if (!lotDbId) continue;
+  // Distribute devices across lots proportional to each lot's current_occupancy.
+  // Each lot's current_occupancy is already the raw device count, so we use that
+  // as the number of unique devices that should have recent events in that lot.
+  let hashCursor = 0;
+  for (const lot of parkingLots) {
+    const lotDbId = lotMap.get(lot.lot_id);
+    if (!lotDbId) continue;
 
+    const numDevices = lot.current_occupancy;
+    for (let d = 0; d < numDevices && hashCursor < allDeviceHashes.length; d++) {
+      const deviceHash = allDeviceHashes[hashCursor++];
+
+      // Create an ENTER event within the last 90 minutes (inside the 2-hour window)
+      const minutesAgo = Math.floor(Math.random() * 90);
+      const eventTimestamp = new Date(now.getTime() - minutesAgo * 60 * 1000);
+
+      eventRows.push({
+        lot_id: lotDbId,
+        event_type: EventType.ENTER,
+        device_hash: deviceHash,
+        timestamp: eventTimestamp,
+      });
+
+      // Track device state for deduplication
       deviceStateRows.push({
         device_hash: deviceHash,
         lot_id: lotDbId,
-        last_event_type: Math.random() > 0.5 ? EventType.ENTER : EventType.EXIT,
-        updated_at: new Date(now.getTime() - Math.floor(Math.random() * 60) * 60 * 1000),
+        last_event_type: EventType.ENTER,
+        updated_at: eventTimestamp,
       });
     }
   }
 
-  await prisma.deviceState.createMany({ data: deviceStateRows });
+  // Batch insert events in chunks of 500
+  for (let i = 0; i < eventRows.length; i += 500) {
+    await prisma.occupancyEvent.createMany({ data: eventRows.slice(i, i + 500) });
+  }
+  console.log(`[seed] Seeded ${eventRows.length} occupancy events (${hashCursor} unique devices)\n`);
+
+  // 9. Seed Device State (deduplication records)
+  console.log('[seed] Seeding device state records...');
+  for (let i = 0; i < deviceStateRows.length; i += 500) {
+    await prisma.deviceState.createMany({ data: deviceStateRows.slice(i, i + 500) });
+  }
   console.log(`[seed] Seeded ${deviceStateRows.length} device state records\n`);
 
   // 10. Verify
@@ -880,6 +940,8 @@ async function main() {
     favorites: await prisma.userFavorite.count(),
     events: await prisma.campusEvent.count(),
     impacts: await prisma.eventImpact.count(),
+    academicPeriods: await prisma.academicCalendar.count(),
+    campusClosures: await prisma.campusClosure.count(),
     weather: await prisma.weather.count(),
     snapshots: await prisma.occupancySnapshot.count(),
     occEvents: await prisma.occupancyEvent.count(),

--- a/apps/backend/src/lots/academic-calendar.spec.ts
+++ b/apps/backend/src/lots/academic-calendar.spec.ts
@@ -1,0 +1,546 @@
+import {
+  generateAcademicYear,
+  getWeekOfSemester,
+  isClassDay,
+  getSemesterProgress,
+  getSemester,
+  isCampusOpen,
+  getExpectedCommuters,
+  COMMUTER_MAP,
+  type AcademicYear,
+} from './academic-calendar';
+
+// ─── Helpers ──────────────────────────────────────────────
+
+/** Local-time date (the calendar module reads getFullYear/getMonth/getDate) */
+const d = (year: number, month: number, day: number): Date =>
+  new Date(year, month - 1, day, 10, 0, 0, 0);
+
+/** Day-of-week helper (0=Sun) for sanity-checking generated dates */
+const dow = (date: Date): number => date.getUTCDay();
+
+// ─── Tests ────────────────────────────────────────────────
+
+describe('Academic Calendar', () => {
+  // ─── generateAcademicYear ────────────────────────────────
+
+  describe('generateAcademicYear', () => {
+    let year2025: AcademicYear;
+
+    beforeAll(() => {
+      year2025 = generateAcademicYear(2025);
+    });
+
+    it('returns all five semesters', () => {
+      expect(year2025.fall).toBeDefined();
+      expect(year2025.spring).toBeDefined();
+      expect(year2025.winter).toBeDefined();
+      expect(year2025.mayIntersession).toBeDefined();
+      expect(year2025.summer).toBeDefined();
+    });
+
+    it('caches results for the same year', () => {
+      const a = generateAcademicYear(2025);
+      const b = generateAcademicYear(2025);
+      expect(a).toBe(b); // same reference
+    });
+
+    // ── Fall semester ──
+
+    describe('Fall 2025', () => {
+      it('starts classes on the 4th Monday of August 2025', () => {
+        const classesStart = year2025.fall.classesStart;
+        expect(classesStart.getUTCMonth()).toBe(7); // August (0-indexed)
+        expect(dow(classesStart)).toBe(1); // Monday
+        // 4th Monday of Aug 2025 = Aug 25
+        expect(classesStart.getUTCDate()).toBe(25);
+      });
+
+      it('has orientation week before classes start', () => {
+        const diff = year2025.fall.classesStart.getTime() - year2025.fall.semesterStart.getTime();
+        expect(diff).toBe(7 * 86_400_000); // 7 days
+      });
+
+      it('has finals week', () => {
+        expect(year2025.fall.finalsStart).not.toBeNull();
+        expect(year2025.fall.finalsEnd).not.toBeNull();
+      });
+
+      it('includes Labor Day break', () => {
+        const laborDay = year2025.fall.breaks.find(b => b.name === 'Labor Day');
+        expect(laborDay).toBeDefined();
+        expect(laborDay!.campusClosed).toBe(true);
+        expect(dow(laborDay!.dates[0])).toBe(1); // Monday
+      });
+
+      it('includes Veterans Day break', () => {
+        const vets = year2025.fall.breaks.find(b => b.name === 'Veterans Day');
+        expect(vets).toBeDefined();
+        expect(vets!.campusClosed).toBe(true);
+      });
+
+      it('includes Thanksgiving break (campus closed)', () => {
+        const tg = year2025.fall.breaks.find(b => b.name === 'Thanksgiving');
+        expect(tg).toBeDefined();
+        expect(tg!.campusClosed).toBe(true);
+        // Thanksgiving is 4th Thursday of November
+        expect(tg!.dates.some(dt => dow(dt) === 4)).toBe(true);
+      });
+
+      it('includes Fall Break (campus open)', () => {
+        const fb = year2025.fall.breaks.find(b => b.name === 'Fall Break');
+        expect(fb).toBeDefined();
+        expect(fb!.campusClosed).toBe(false);
+        expect(fb!.dates.length).toBe(3);
+      });
+
+      it('has a reading day', () => {
+        expect(year2025.fall.readingDays.length).toBe(1);
+      });
+    });
+
+    // ── Spring semester ──
+
+    describe('Spring 2026', () => {
+      it('starts the day after MLK Day', () => {
+        const classesStart = year2025.spring.classesStart;
+        // MLK Day 2026 = 3rd Mon of Jan = Jan 19
+        expect(classesStart.getUTCMonth()).toBe(0); // January
+        expect(dow(classesStart)).toBe(2); // Tuesday
+        expect(classesStart.getUTCDate()).toBe(20);
+      });
+
+      it('includes Spring Recess', () => {
+        const recess = year2025.spring.breaks.find(b => b.name === 'Spring Recess');
+        expect(recess).toBeDefined();
+        expect(recess!.dates.length).toBe(7); // full week
+        expect(recess!.campusClosed).toBe(false);
+      });
+
+      it('includes Cesar Chavez Day (campus closed)', () => {
+        const cc = year2025.spring.breaks.find(b => b.name === 'Cesar Chavez Day');
+        expect(cc).toBeDefined();
+        expect(cc!.campusClosed).toBe(true);
+      });
+
+      it('has finals', () => {
+        expect(year2025.spring.finalsStart).not.toBeNull();
+        expect(year2025.spring.finalsEnd).not.toBeNull();
+      });
+    });
+
+    // ── Winter intersession ──
+
+    describe('Winter 2026', () => {
+      it('starts on or after January 2', () => {
+        const start = year2025.winter.classesStart;
+        expect(start.getUTCMonth()).toBe(0);
+        expect(start.getUTCDate()).toBeGreaterThanOrEqual(2);
+        // Should be a weekday
+        expect(dow(start)).toBeGreaterThanOrEqual(1);
+        expect(dow(start)).toBeLessThanOrEqual(5);
+      });
+
+      it('ends on MLK Day', () => {
+        const mlk = year2025.winter.semesterEnd;
+        expect(dow(mlk)).toBe(1); // Monday
+        expect(mlk.getUTCMonth()).toBe(0); // January
+      });
+
+      it('has no finals', () => {
+        expect(year2025.winter.finalsStart).toBeNull();
+        expect(year2025.winter.finalsEnd).toBeNull();
+      });
+
+      it('includes MLK Day break', () => {
+        const mlkBreak = year2025.winter.breaks.find(b =>
+          b.name.includes('Martin Luther King'),
+        );
+        expect(mlkBreak).toBeDefined();
+        expect(mlkBreak!.campusClosed).toBe(true);
+      });
+    });
+
+    // ── May intersession ──
+
+    describe('May Intersession 2026', () => {
+      it('starts after spring finals on a Monday', () => {
+        const start = year2025.mayIntersession.classesStart;
+        expect(dow(start)).toBe(1); // Monday
+        // Must be after spring finals
+        expect(start.getTime()).toBeGreaterThan(year2025.spring.finalsEnd!.getTime());
+      });
+
+      it('lasts about 3 weeks', () => {
+        const { classesStart, classesEnd } = year2025.mayIntersession;
+        const days = Math.round(
+          (classesEnd.getTime() - classesStart.getTime()) / 86_400_000,
+        );
+        expect(days).toBe(18);
+      });
+
+      it('has no finals', () => {
+        expect(year2025.mayIntersession.finalsStart).toBeNull();
+      });
+    });
+
+    // ── Summer session ──
+
+    describe('Summer 2026', () => {
+      it('starts the day after May intersession ends', () => {
+        const expected = new Date(
+          year2025.mayIntersession.semesterEnd.getTime() + 86_400_000,
+        );
+        expect(year2025.summer.classesStart.getTime()).toBe(expected.getTime());
+      });
+
+      it('lasts about 10 weeks', () => {
+        const { classesStart, classesEnd } = year2025.summer;
+        const days = Math.round(
+          (classesEnd.getTime() - classesStart.getTime()) / 86_400_000,
+        );
+        expect(days).toBe(69);
+      });
+
+      it('includes Juneteenth if in session', () => {
+        const jt = year2025.summer.breaks.find(b => b.name === 'Juneteenth');
+        if (jt) {
+          expect(jt.campusClosed).toBe(true);
+        }
+      });
+
+      it('includes Independence Day if in session', () => {
+        const id4 = year2025.summer.breaks.find(b => b.name === 'Independence Day');
+        if (id4) {
+          expect(id4.campusClosed).toBe(true);
+        }
+      });
+    });
+  });
+
+  // ─── getSemester ─────────────────────────────────────────
+
+  describe('getSemester', () => {
+    it('classifies a fall class day as fall', () => {
+      // Sept 15 2025 is clearly in fall
+      expect(getSemester(d(2025, 9, 15))).toBe('fall');
+    });
+
+    it('classifies a spring class day as spring', () => {
+      // March 10 2026 is in spring
+      expect(getSemester(d(2026, 3, 10))).toBe('spring');
+    });
+
+    it('classifies July as summer', () => {
+      expect(getSemester(d(2026, 7, 1))).toBe('summer');
+    });
+
+    it('classifies winter intersession as session', () => {
+      // Jan 5 2026 should be winter intersession
+      expect(getSemester(d(2026, 1, 5))).toBe('session');
+    });
+
+    it('classifies a date between semesters as break', () => {
+      // Late December — between fall and winter
+      expect(getSemester(d(2025, 12, 28))).toBe('break');
+    });
+  });
+
+  // ─── isClassDay ──────────────────────────────────────────
+
+  describe('isClassDay', () => {
+    it('returns true for a normal Monday during spring', () => {
+      // Mon March 9 2026 — regular spring day
+      expect(isClassDay(d(2026, 3, 9))).toBe(true);
+    });
+
+    it('returns false for Saturday', () => {
+      expect(isClassDay(d(2026, 3, 14))).toBe(false);
+    });
+
+    it('returns false for Sunday', () => {
+      expect(isClassDay(d(2026, 3, 15))).toBe(false);
+    });
+
+    it('returns false for a campus holiday (Labor Day 2025)', () => {
+      // Labor Day 2025 = Sep 1
+      expect(isClassDay(d(2025, 9, 1))).toBe(false);
+    });
+
+    it('returns false for a date outside any semester', () => {
+      expect(isClassDay(d(2025, 12, 28))).toBe(false);
+    });
+
+    it('returns false during Spring Recess', () => {
+      // Spring Recess includes week of March 31
+      const year = generateAcademicYear(2025);
+      const recessDate = year.spring.breaks.find(
+        b => b.name === 'Spring Recess',
+      )!.dates[2]; // a weekday in recess (not Cesar Chavez Day)
+      // Convert UTC date to local params for d()
+      expect(
+        isClassDay(
+          d(recessDate.getUTCFullYear(), recessDate.getUTCMonth() + 1, recessDate.getUTCDate()),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  // ─── getWeekOfSemester ───────────────────────────────────
+
+  describe('getWeekOfSemester', () => {
+    it('returns [0, "break"] for a date outside any semester', () => {
+      expect(getWeekOfSemester(d(2025, 12, 28))).toEqual([0, 'break']);
+    });
+
+    it('returns week 1, "early" for the first day of fall classes', () => {
+      const year = generateAcademicYear(2025);
+      const cs = year.fall.classesStart;
+      const result = getWeekOfSemester(
+        d(cs.getUTCFullYear(), cs.getUTCMonth() + 1, cs.getUTCDate()),
+      );
+      expect(result[0]).toBe(1);
+      expect(result[1]).toBe('early');
+    });
+
+    it('returns "midterms" around week 8-9', () => {
+      const year = generateAcademicYear(2025);
+      const cs = year.fall.classesStart;
+      // 7 weeks * 7 days = 49 days → week 8
+      const midtermDate = new Date(cs.getTime() + 49 * 86_400_000);
+      const result = getWeekOfSemester(
+        d(midtermDate.getUTCFullYear(), midtermDate.getUTCMonth() + 1, midtermDate.getUTCDate()),
+      );
+      expect(result[0]).toBe(8);
+      expect(result[1]).toBe('midterms');
+    });
+
+    it('returns "finals" during finals week', () => {
+      const year = generateAcademicYear(2025);
+      const fs = year.fall.finalsStart!;
+      const result = getWeekOfSemester(
+        d(fs.getUTCFullYear(), fs.getUTCMonth() + 1, fs.getUTCDate()),
+      );
+      expect(result[1]).toBe('finals');
+    });
+
+    it('returns "break" for an in-semester break day', () => {
+      const year = generateAcademicYear(2025);
+      const laborDay = year.fall.breaks.find(b => b.name === 'Labor Day')!.dates[0];
+      const result = getWeekOfSemester(
+        d(laborDay.getUTCFullYear(), laborDay.getUTCMonth() + 1, laborDay.getUTCDate()),
+      );
+      expect(result[1]).toBe('break');
+    });
+
+    it('returns "regular" for intersession even on week 1', () => {
+      const year = generateAcademicYear(2025);
+      const cs = year.winter.classesStart;
+      const result = getWeekOfSemester(
+        d(cs.getUTCFullYear(), cs.getUTCMonth() + 1, cs.getUTCDate()),
+      );
+      expect(result[1]).toBe('regular');
+    });
+  });
+
+  // ─── getSemesterProgress ─────────────────────────────────
+
+  describe('getSemesterProgress', () => {
+    it('returns 0 for a date outside any semester', () => {
+      expect(getSemesterProgress(d(2025, 12, 28))).toBe(0);
+    });
+
+    it('returns 0 at classesStart', () => {
+      const year = generateAcademicYear(2025);
+      const cs = year.fall.classesStart;
+      expect(
+        getSemesterProgress(
+          d(cs.getUTCFullYear(), cs.getUTCMonth() + 1, cs.getUTCDate()),
+        ),
+      ).toBe(0);
+    });
+
+    it('returns ~0.5 near midpoint', () => {
+      const year = generateAcademicYear(2025);
+      const cs = year.fall.classesStart;
+      const fe = year.fall.finalsEnd!;
+      const total = (fe.getTime() - cs.getTime()) / 86_400_000;
+      const mid = new Date(cs.getTime() + Math.floor(total / 2) * 86_400_000);
+      const progress = getSemesterProgress(
+        d(mid.getUTCFullYear(), mid.getUTCMonth() + 1, mid.getUTCDate()),
+      );
+      expect(progress).toBeGreaterThan(0.4);
+      expect(progress).toBeLessThan(0.6);
+    });
+
+    it('returns 1 after finalsEnd', () => {
+      const year = generateAcademicYear(2025);
+      const fe = year.fall.finalsEnd!;
+      const after = new Date(fe.getTime() + 2 * 86_400_000);
+      const progress = getSemesterProgress(
+        d(after.getUTCFullYear(), after.getUTCMonth() + 1, after.getUTCDate()),
+      );
+      // Still in semester but past finalsEnd → 1.0
+      expect(progress).toBe(1);
+    });
+  });
+
+  // ─── isCampusOpen ────────────────────────────────────────
+
+  describe('isCampusOpen', () => {
+    it('returns true for a normal class day', () => {
+      expect(isCampusOpen(d(2026, 3, 10))).toBe(true);
+    });
+
+    it('returns false on Labor Day', () => {
+      // Labor Day 2025 = Sep 1
+      expect(isCampusOpen(d(2025, 9, 1))).toBe(false);
+    });
+
+    it('returns false on Thanksgiving', () => {
+      const year = generateAcademicYear(2025);
+      const tg = year.fall.breaks.find(b => b.name === 'Thanksgiving')!.dates[0];
+      expect(
+        isCampusOpen(
+          d(tg.getUTCFullYear(), tg.getUTCMonth() + 1, tg.getUTCDate()),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns true on Spring Recess (campus open, no classes)', () => {
+      const year = generateAcademicYear(2025);
+      const recess = year.spring.breaks.find(
+        b => b.name === 'Spring Recess',
+      )!.dates[0]; // Monday of recess week (not Cesar Chavez Day)
+      expect(
+        isCampusOpen(
+          d(recess.getUTCFullYear(), recess.getUTCMonth() + 1, recess.getUTCDate()),
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false on Cesar Chavez Day', () => {
+      const year = generateAcademicYear(2025);
+      const cc = year.spring.breaks.find(b => b.name === 'Cesar Chavez Day')!.dates[0];
+      expect(
+        isCampusOpen(
+          d(cc.getUTCFullYear(), cc.getUTCMonth() + 1, cc.getUTCDate()),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns true for a date between semesters', () => {
+      expect(isCampusOpen(d(2025, 12, 28))).toBe(true);
+    });
+  });
+
+  // ─── getExpectedCommuters ────────────────────────────────
+
+  describe('getExpectedCommuters', () => {
+    it('returns fall commuters for a regular fall day', () => {
+      expect(getExpectedCommuters(d(2025, 9, 15))).toBe(COMMUTER_MAP.fall); // 35,000
+    });
+
+    it('returns spring commuters for a regular spring day', () => {
+      expect(getExpectedCommuters(d(2026, 3, 10))).toBe(COMMUTER_MAP.spring); // 34,000
+    });
+
+    it('returns summer commuters for a summer day', () => {
+      const year = generateAcademicYear(2025);
+      const summerDay = new Date(
+        year.summer.classesStart.getTime() + 7 * 86_400_000,
+      );
+      expect(
+        getExpectedCommuters(
+          d(summerDay.getUTCFullYear(), summerDay.getUTCMonth() + 1, summerDay.getUTCDate()),
+        ),
+      ).toBe(COMMUTER_MAP.summer); // 8,000
+    });
+
+    it('returns session commuters for winter intersession', () => {
+      expect(getExpectedCommuters(d(2026, 1, 5))).toBe(COMMUTER_MAP.session); // 3,000
+    });
+
+    it('returns break commuters between semesters', () => {
+      expect(getExpectedCommuters(d(2025, 12, 28))).toBe(COMMUTER_MAP.break); // 1,500
+    });
+
+    it('returns break commuters on campus-closed holidays', () => {
+      // Labor Day 2025 = Sep 1
+      expect(getExpectedCommuters(d(2025, 9, 1))).toBe(COMMUTER_MAP.break); // 1,500
+    });
+
+    it('returns 10% of normal on in-semester break days (Spring Recess)', () => {
+      const year = generateAcademicYear(2025);
+      const recess = year.spring.breaks.find(
+        b => b.name === 'Spring Recess',
+      )!.dates[0]; // Monday of recess week (not Cesar Chavez Day)
+      const result = getExpectedCommuters(
+        d(recess.getUTCFullYear(), recess.getUTCMonth() + 1, recess.getUTCDate()),
+      );
+      // Spring = 34,000 × 0.10 = 3,400
+      expect(result).toBe(Math.round(COMMUTER_MAP.spring * 0.1));
+    });
+
+    it('returns 10% of normal on Fall Break days', () => {
+      const year = generateAcademicYear(2025);
+      const fb = year.fall.breaks.find(b => b.name === 'Fall Break')!.dates[0];
+      const result = getExpectedCommuters(
+        d(fb.getUTCFullYear(), fb.getUTCMonth() + 1, fb.getUTCDate()),
+      );
+      // Fall = 35,000 × 0.10 = 3,500
+      expect(result).toBe(Math.round(COMMUTER_MAP.fall * 0.1));
+    });
+  });
+
+  // ─── Observed-holiday edge cases ─────────────────────────
+
+  describe('Federal observed-holiday rules', () => {
+    it('moves Veterans Day from Saturday to Friday', () => {
+      // Find a year where Nov 11 is Saturday
+      // 2023: Nov 11 = Saturday
+      const year = generateAcademicYear(2023);
+      const vets = year.fall.breaks.find(b => b.name === 'Veterans Day');
+      expect(vets).toBeDefined();
+      // Should be observed Friday Nov 10
+      expect(vets!.dates[0].getUTCDate()).toBe(10);
+      expect(dow(vets!.dates[0])).toBe(5); // Friday
+    });
+
+    it('moves Veterans Day from Sunday to Monday', () => {
+      // 2018: Nov 11 = Sunday
+      const year = generateAcademicYear(2018);
+      const vets = year.fall.breaks.find(b => b.name === 'Veterans Day');
+      expect(vets).toBeDefined();
+      // Should be observed Monday Nov 12
+      expect(vets!.dates[0].getUTCDate()).toBe(12);
+      expect(dow(vets!.dates[0])).toBe(1); // Monday
+    });
+  });
+
+  // ─── Multi-year consistency ──────────────────────────────
+
+  describe('Multi-year consistency', () => {
+    const years = [2020, 2021, 2022, 2023, 2024, 2025, 2026, 2027];
+
+    it.each(years)('year %d: fall classes start on a Monday in August', (y) => {
+      const year = generateAcademicYear(y);
+      expect(dow(year.fall.classesStart)).toBe(1); // Monday
+      expect(year.fall.classesStart.getUTCMonth()).toBe(7); // August
+    });
+
+    it.each(years)('year %d: spring classes start on a Tuesday', (y) => {
+      const year = generateAcademicYear(y);
+      expect(dow(year.spring.classesStart)).toBe(2); // Tuesday
+    });
+
+    it.each(years)('year %d: all semesters have valid date ranges', (y) => {
+      const year = generateAcademicYear(y);
+      for (const key of ['fall', 'spring', 'winter', 'mayIntersession', 'summer'] as const) {
+        const sem = year[key];
+        expect(sem.semesterStart.getTime()).toBeLessThanOrEqual(sem.semesterEnd.getTime());
+        expect(sem.classesStart.getTime()).toBeLessThanOrEqual(sem.classesEnd.getTime());
+      }
+    });
+  });
+});

--- a/apps/backend/src/lots/academic-calendar.spec.ts
+++ b/apps/backend/src/lots/academic-calendar.spec.ts
@@ -187,19 +187,18 @@ describe('Academic Calendar', () => {
     // ── Summer session ──
 
     describe('Summer 2026', () => {
-      it('starts the day after May intersession ends', () => {
-        const expected = new Date(
-          year2025.mayIntersession.semesterEnd.getTime() + 86_400_000,
-        );
+      it('starts on the last Tuesday of May', () => {
+        // Last Tuesday of May 2026 is May 26
+        const expected = new Date('2026-05-26T00:00:00Z');
         expect(year2025.summer.classesStart.getTime()).toBe(expected.getTime());
       });
 
-      it('lasts about 10 weeks', () => {
+      it('lasts about 12 weeks', () => {
         const { classesStart, classesEnd } = year2025.summer;
         const days = Math.round(
           (classesEnd.getTime() - classesStart.getTime()) / 86_400_000,
         );
-        expect(days).toBe(69);
+        expect(days).toBe(83);
       });
 
       it('includes Juneteenth if in session', () => {

--- a/apps/backend/src/lots/academic-calendar.ts
+++ b/apps/backend/src/lots/academic-calendar.ts
@@ -73,7 +73,7 @@ export const COMMUTER_MAP: Record<SemesterCategory, number> = {
 const IN_SEMESTER_BREAK_FRACTION = 0.10;
 
 const INTERSESSION_KEYS = new Set<SemesterKey>(['winter', 'mayIntersession', 'summer']);
-const SEMESTER_ORDER: SemesterKey[] = ['fall', 'winter', 'spring', 'mayIntersession', 'summer'];
+const SEMESTER_ORDER: SemesterKey[] = ['fall', 'winter', 'spring', 'summer', 'mayIntersession'];
 const SEMESTER_CATEGORY_MAP: Record<SemesterKey, SemesterCategory> = {
   fall: 'fall',
   spring: 'spring',
@@ -255,9 +255,12 @@ function generateMayIntersession(spring: SemesterInfo): SemesterInfo {
   };
 }
 
-function generateSummer(may: SemesterInfo, year: number): SemesterInfo {
-  const start = addDays(may.semesterEnd, 1);
-  const end = addDays(start, 69); // ~10 weeks
+function generateSummer(year: number): SemesterInfo {
+  // 12-week session starting last Tuesday of May (~May 26)
+  // This overlaps the last 2 weeks of may-intersession, but summer is prioritized
+  // in lookups (SEMESTER_ORDER) to correctly estimate 8K commuters instead of 3K
+  const start = lastWeekday(year, 5, 2); // Tuesday = 2 in UTC day convention
+  const end = addDays(start, 83); // 12 weeks
 
   const juneteenth = observe(utc(year, 6, 19));
   const independenceDay = observe(utc(year, 7, 4));
@@ -293,7 +296,7 @@ export function generateAcademicYear(startYear: number): AcademicYear {
   const spring = generateSpring(nextYear);
   const winter = generateWinter(nextYear);
   const mayIntersession = generateMayIntersession(spring);
-  const summer = generateSummer(mayIntersession, nextYear);
+  const summer = generateSummer(nextYear);
 
   const year: AcademicYear = { fall, spring, winter, mayIntersession, summer };
   cache.set(startYear, year);

--- a/apps/backend/src/lots/academic-calendar.ts
+++ b/apps/backend/src/lots/academic-calendar.ts
@@ -1,0 +1,455 @@
+/**
+ * CSULB Academic Calendar — Rule-Based Heuristics
+ *
+ * TypeScript port of services/ml/src/academic_calendar.py
+ *
+ * Computes semester dates dynamically for any academic year using
+ * CSULB's predictable calendar patterns. No database tables or hardcoded
+ * per-year data needed.
+ *
+ * Heuristic rules:
+ *   - Fall: classes start on the 4th Monday of August (~16-week semester)
+ *   - Spring: classes start the Tuesday after MLK Day (3rd Monday of January)
+ *   - Winter intersession: first weekday on/after January 2 through MLK Day
+ *   - May intersession: Monday after spring finals for ~3 weeks
+ *   - Summer session: follows May intersession for ~10 weeks
+ *   - Holidays follow federal observed-holiday rules (Sat→Fri, Sun→Mon)
+ *
+ * Why heuristics over hardcoded dates:
+ *   CSULB has followed these patterns consistently. For real-time estimation
+ *   and ML features, what matters is category-level accuracy (classes vs.
+ *   finals vs. break). If CSULB changes their scheduling pattern, update
+ *   the generate* functions.
+ */
+
+// ─── Types ─────────────────────────────────────────────────
+
+export interface SemesterBreak {
+  name: string;
+  dates: Date[];
+  campusClosed: boolean;
+}
+
+export interface SemesterInfo {
+  semesterStart: Date;
+  semesterEnd: Date;
+  classesStart: Date;
+  classesEnd: Date;
+  finalsStart: Date | null;
+  finalsEnd: Date | null;
+  breaks: SemesterBreak[];
+  readingDays: Date[];
+}
+
+export interface AcademicYear {
+  fall: SemesterInfo;
+  spring: SemesterInfo;
+  winter: SemesterInfo;
+  mayIntersession: SemesterInfo;
+  summer: SemesterInfo;
+}
+
+export type SemesterKey = 'fall' | 'spring' | 'winter' | 'mayIntersession' | 'summer';
+export type PeriodType = 'early' | 'regular' | 'midterms' | 'late' | 'dead_week' | 'finals' | 'break';
+export type SemesterCategory = 'fall' | 'spring' | 'summer' | 'session' | 'break';
+
+// ─── Constants ─────────────────────────────────────────────
+
+const DAY_MS = 86_400_000;
+
+/** Day-of-week (JS convention: 0 = Sunday, 6 = Saturday) */
+const SUN = 0, MON = 1, THU = 4, SAT = 6;
+
+/** Expected daily commuters by semester category */
+export const COMMUTER_MAP: Record<SemesterCategory, number> = {
+  fall: 35_000,
+  spring: 34_000,
+  summer: 8_000,
+  session: 3_000,
+  break: 1_500,
+};
+
+/** In-semester break: fraction of normal commuters (staff/employees only) */
+const IN_SEMESTER_BREAK_FRACTION = 0.10;
+
+const INTERSESSION_KEYS = new Set<SemesterKey>(['winter', 'mayIntersession', 'summer']);
+const SEMESTER_ORDER: SemesterKey[] = ['fall', 'winter', 'spring', 'mayIntersession', 'summer'];
+const SEMESTER_CATEGORY_MAP: Record<SemesterKey, SemesterCategory> = {
+  fall: 'fall',
+  spring: 'spring',
+  winter: 'session',
+  mayIntersession: 'session',
+  summer: 'summer',
+};
+
+// ─── Internal Date Utilities ───────────────────────────────
+// All internal calendar dates use UTC midnight for clean comparisons.
+// Public API accepts any Date and extracts year/month/day via local getters.
+
+function utc(year: number, month: number, day: number): Date {
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function addDays(d: Date, n: number): Date {
+  return new Date(d.getTime() + n * DAY_MS);
+}
+
+function dow(d: Date): number {
+  return d.getUTCDay();
+}
+
+function lte(a: Date, b: Date): boolean {
+  return a.getTime() <= b.getTime();
+}
+
+function inSet(d: Date, dates: Date[]): boolean {
+  const t = d.getTime();
+  return dates.some(x => x.getTime() === t);
+}
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.round((b.getTime() - a.getTime()) / DAY_MS);
+}
+
+/** Convert any Date to a UTC midnight date using its local year/month/day */
+function toCalDate(d: Date): Date {
+  return utc(d.getFullYear(), d.getMonth() + 1, d.getDate());
+}
+
+/** nth weekday of month (weekday: 0=Sun..6=Sat, n: 1-based) */
+function nthWeekday(year: number, month: number, weekday: number, n: number): Date {
+  const firstDow = dow(utc(year, month, 1));
+  const daysAhead = (weekday - firstDow + 7) % 7;
+  return utc(year, month, 1 + daysAhead + (n - 1) * 7);
+}
+
+/** Last weekday of month */
+function lastWeekday(year: number, month: number, weekday: number): Date {
+  const lastDayNum = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const lastDow = dow(utc(year, month, lastDayNum));
+  const daysBack = (lastDow - weekday + 7) % 7;
+  return utc(year, month, lastDayNum - daysBack);
+}
+
+/** Federal observed-holiday rule: Sat → Fri, Sun → Mon */
+function observe(d: Date): Date {
+  if (dow(d) === SAT) return addDays(d, -1);
+  if (dow(d) === SUN) return addDays(d, 1);
+  return d;
+}
+
+/** Monday of the ISO week containing the given date */
+function mondayOfWeek(d: Date): Date {
+  const day = dow(d);
+  const offset = day === SUN ? 6 : day - MON;
+  return addDays(d, -offset);
+}
+
+// ─── Calendar Generation ───────────────────────────────────
+
+function generateFall(year: number): SemesterInfo {
+  // 4th Monday of August
+  const classesStart = nthWeekday(year, 8, MON, 4);
+  const semesterStart = addDays(classesStart, -7); // orientation week
+  const classesEnd = addDays(classesStart, 107);   // Wednesday of week 16
+  const readingDay = addDays(classesEnd, 1);        // Thursday
+  const finalsStart = addDays(classesEnd, 2);       // Friday
+  const finalsEnd = addDays(finalsStart, 6);        // following Thursday
+  const semesterEnd = addDays(finalsEnd, 6);
+
+  const laborDay = nthWeekday(year, 9, MON, 1);
+  const veteransDay = observe(utc(year, 11, 11));
+  const thanksgiving = nthWeekday(year, 11, THU, 4);
+  const fallBreakStart = addDays(thanksgiving, -3); // Monday of Thanksgiving week
+
+  return {
+    semesterStart, semesterEnd, classesStart, classesEnd,
+    finalsStart, finalsEnd,
+    readingDays: [readingDay],
+    breaks: [
+      { name: 'Labor Day', dates: [laborDay], campusClosed: true },
+      { name: 'Veterans Day', dates: [veteransDay], campusClosed: true },
+      {
+        name: 'Fall Break',
+        dates: [fallBreakStart, addDays(fallBreakStart, 1), addDays(fallBreakStart, 2)],
+        campusClosed: false,
+      },
+      {
+        name: 'Thanksgiving',
+        dates: [thanksgiving, addDays(thanksgiving, 1), addDays(thanksgiving, 2), addDays(thanksgiving, 3)],
+        campusClosed: true,
+      },
+    ],
+  };
+}
+
+function generateSpring(year: number): SemesterInfo {
+  // Tuesday after MLK Day (3rd Monday of January)
+  const mlkDay = nthWeekday(year, 1, MON, 3);
+  const classesStart = addDays(mlkDay, 1);
+  const classesEnd = addDays(classesStart, 107);
+  const finalsStart = addDays(classesEnd, 3);  // following Monday
+  const finalsEnd = addDays(finalsStart, 5);   // Saturday
+  const semesterEnd = addDays(finalsEnd, 1);   // Sunday
+
+  // Spring Recess: full week (Mon-Sun) containing March 31
+  const mar31 = utc(year, 3, 31);
+  const recessStart = mondayOfWeek(mar31);
+  const springRecessDates = Array.from({ length: 7 }, (_, i) => addDays(recessStart, i));
+
+  // Cesar Chavez Day (March 31, observed)
+  const cesarChavez = observe(mar31);
+
+  return {
+    semesterStart: classesStart, semesterEnd, classesStart, classesEnd,
+    finalsStart, finalsEnd,
+    readingDays: [],
+    breaks: [
+      { name: 'Spring Recess', dates: springRecessDates, campusClosed: false },
+      { name: 'Cesar Chavez Day', dates: [cesarChavez], campusClosed: true },
+    ],
+  };
+}
+
+function generateWinter(year: number): SemesterInfo {
+  // First weekday on or after January 2
+  const jan2 = utc(year, 1, 2);
+  let start: Date;
+  if (dow(jan2) === SAT) start = addDays(jan2, 2);
+  else if (dow(jan2) === SUN) start = addDays(jan2, 1);
+  else start = jan2;
+
+  const mlkDay = nthWeekday(year, 1, MON, 3);
+
+  return {
+    semesterStart: start, semesterEnd: mlkDay,
+    classesStart: start, classesEnd: mlkDay,
+    finalsStart: null, finalsEnd: null,
+    readingDays: [],
+    breaks: [
+      { name: 'Martin Luther King Jr. Day', dates: [mlkDay], campusClosed: true },
+    ],
+  };
+}
+
+function generateMayIntersession(spring: SemesterInfo): SemesterInfo {
+  const finalsEnd = spring.finalsEnd!;
+  let daysToMon = (MON - dow(finalsEnd) + 7) % 7;
+  if (daysToMon === 0) daysToMon = 7;
+  const start = addDays(finalsEnd, daysToMon);
+  const end = addDays(start, 18); // ~3 weeks
+
+  const memorialDay = lastWeekday(start.getUTCFullYear(), 5, MON);
+
+  const breaks: SemesterBreak[] = [];
+  if (lte(start, memorialDay) && lte(memorialDay, end)) {
+    breaks.push({ name: 'Memorial Day', dates: [memorialDay], campusClosed: true });
+  }
+
+  return {
+    semesterStart: start, semesterEnd: end,
+    classesStart: start, classesEnd: end,
+    finalsStart: null, finalsEnd: null,
+    readingDays: [],
+    breaks,
+  };
+}
+
+function generateSummer(may: SemesterInfo, year: number): SemesterInfo {
+  const start = addDays(may.semesterEnd, 1);
+  const end = addDays(start, 69); // ~10 weeks
+
+  const juneteenth = observe(utc(year, 6, 19));
+  const independenceDay = observe(utc(year, 7, 4));
+
+  const breaks: SemesterBreak[] = [];
+  if (lte(start, juneteenth) && lte(juneteenth, end)) {
+    breaks.push({ name: 'Juneteenth', dates: [juneteenth], campusClosed: true });
+  }
+  if (lte(start, independenceDay) && lte(independenceDay, end)) {
+    breaks.push({ name: 'Independence Day', dates: [independenceDay], campusClosed: true });
+  }
+
+  return {
+    semesterStart: start, semesterEnd: end,
+    classesStart: start, classesEnd: end,
+    finalsStart: null, finalsEnd: null,
+    readingDays: [],
+    breaks,
+  };
+}
+
+// ─── Year Generation & Cache ───────────────────────────────
+
+const cache = new Map<number, AcademicYear>();
+
+/** Generate (or retrieve from cache) the full academic year starting in `startYear`. */
+export function generateAcademicYear(startYear: number): AcademicYear {
+  const cached = cache.get(startYear);
+  if (cached) return cached;
+
+  const nextYear = startYear + 1;
+  const fall = generateFall(startYear);
+  const spring = generateSpring(nextYear);
+  const winter = generateWinter(nextYear);
+  const mayIntersession = generateMayIntersession(spring);
+  const summer = generateSummer(mayIntersession, nextYear);
+
+  const year: AcademicYear = { fall, spring, winter, mayIntersession, summer };
+  cache.set(startYear, year);
+  return year;
+}
+
+// ─── Internal Lookup ───────────────────────────────────────
+
+function allBreakDates(sem: SemesterInfo): Date[] {
+  return sem.breaks.flatMap(b => b.dates);
+}
+
+function allClosedDates(sem: SemesterInfo): Date[] {
+  return sem.breaks.filter(b => b.campusClosed).flatMap(b => b.dates);
+}
+
+/** Academic years run Aug–Jul. Dates Aug+ → that year. Jan–Jul → previous year. */
+function academicYearForDate(d: Date): number {
+  const month = d.getUTCMonth() + 1;
+  return month >= 8 ? d.getUTCFullYear() : d.getUTCFullYear() - 1;
+}
+
+interface SemesterMatch {
+  semester: SemesterInfo;
+  key: SemesterKey;
+  isIntersession: boolean;
+}
+
+function findSemester(d: Date): SemesterMatch | null {
+  const startYear = academicYearForDate(d);
+  const yearData = generateAcademicYear(startYear);
+
+  for (const key of SEMESTER_ORDER) {
+    const sem = yearData[key];
+    if (lte(sem.semesterStart, d) && lte(d, sem.semesterEnd)) {
+      return { semester: sem, key, isIntersession: INTERSESSION_KEYS.has(key) };
+    }
+  }
+  return null;
+}
+
+// ─── Public API ────────────────────────────────────────────
+// All functions accept a Date whose local year/month/day represent the
+// calendar date in the school's timezone. Call toSchoolTime() first if
+// working with UTC timestamps.
+
+/**
+ * Week number (1-based) and academic period classification for a date.
+ *
+ * Period values: early (weeks 1-2), regular (3-7), midterms (8-9),
+ * late (10-14), dead_week (15+), finals, break.
+ * Intersession weeks always return "regular".
+ */
+export function getWeekOfSemester(input: Date): [number, PeriodType] {
+  const d = toCalDate(input);
+  const match = findSemester(d);
+  if (!match) return [0, 'break'];
+
+  const { semester: sem, isIntersession } = match;
+  const breakDates = allBreakDates(sem);
+
+  const week = lte(sem.classesStart, d)
+    ? Math.floor(daysBetween(sem.classesStart, d) / 7) + 1
+    : 0;
+
+  if (inSet(d, breakDates)) return [week, 'break'];
+
+  if (sem.finalsStart && sem.finalsEnd && lte(sem.finalsStart, d) && lte(d, sem.finalsEnd)) {
+    return [week, 'finals'];
+  }
+
+  if (lte(sem.classesStart, d) && lte(d, sem.classesEnd)) {
+    if (isIntersession) return [week, 'regular'];
+    if (week <= 2) return [week, 'early'];
+    if (week <= 7) return [week, 'regular'];
+    if (week <= 9) return [week, 'midterms'];
+    if (week <= 14) return [week, 'late'];
+    return [week, 'dead_week'];
+  }
+
+  if (inSet(d, sem.readingDays)) return [week, 'dead_week'];
+  return [week, 'break'];
+}
+
+/** True if the date is a regular class day (weekday, during instruction, not a break/reading/holiday). */
+export function isClassDay(input: Date): boolean {
+  const d = toCalDate(input);
+  if (dow(d) === SAT || dow(d) === SUN) return false;
+
+  const match = findSemester(d);
+  if (!match) return false;
+
+  const { semester: sem } = match;
+  if (!lte(sem.classesStart, d) || !lte(d, sem.classesEnd)) return false;
+
+  return !inSet(d, allBreakDates(sem)) && !inSet(d, sem.readingDays);
+}
+
+/** How far through the semester (0.0 → 1.0). Uses classesStart to finalsEnd. */
+export function getSemesterProgress(input: Date): number {
+  const d = toCalDate(input);
+  const match = findSemester(d);
+  if (!match) return 0;
+
+  const { semester: sem } = match;
+  const start = sem.classesStart;
+  const end = sem.finalsEnd ?? sem.classesEnd;
+
+  if (lte(d, start)) return 0;
+  if (!lte(d, end)) return 1;
+
+  const total = daysBetween(start, end);
+  return total > 0 ? daysBetween(start, d) / total : 0;
+}
+
+/** Classify a date into a semester category: fall, spring, summer, session, break. */
+export function getSemester(input: Date): SemesterCategory {
+  const d = toCalDate(input);
+  const match = findSemester(d);
+  if (!match) return 'break';
+  return SEMESTER_CATEGORY_MAP[match.key];
+}
+
+/** True if campus is open (not a campus-closed holiday). */
+export function isCampusOpen(input: Date): boolean {
+  const d = toCalDate(input);
+  const match = findSemester(d);
+  if (!match) return true; // dates outside any semester — campus open by default
+  return !inSet(d, allClosedDates(match.semester));
+}
+
+/**
+ * Expected daily commuters for the date's academic context.
+ *
+ * - Regular class day → full commuters for the semester category
+ * - Campus-closed holiday → COMMUTER_MAP.break (minimal staff)
+ * - In-semester break (spring break, fall break) → 10% of normal
+ * - Between semesters → COMMUTER_MAP.break
+ */
+export function getExpectedCommuters(input: Date): number {
+  const d = toCalDate(input);
+  const match = findSemester(d);
+
+  // Between semesters
+  if (!match) return COMMUTER_MAP.break;
+
+  const category = SEMESTER_CATEGORY_MAP[match.key];
+
+  // Campus-closed holidays (Labor Day, Thanksgiving, etc.)
+  if (inSet(d, allClosedDates(match.semester))) return COMMUTER_MAP.break;
+
+  // In-semester break (Spring Recess, Fall Break days that aren't campus-closed)
+  if (inSet(d, allBreakDates(match.semester))) {
+    return Math.round(COMMUTER_MAP[category] * IN_SEMESTER_BREAK_FRACTION);
+  }
+
+  // Regular period (classes, finals, reading days)
+  return COMMUTER_MAP[category];
+}

--- a/apps/backend/src/lots/interfaces/parking-lot.interface.ts
+++ b/apps/backend/src/lots/interfaces/parking-lot.interface.ts
@@ -10,6 +10,14 @@ export interface ParkingLotResponse extends PrismaLot {
   available: number;
   occupancy_rate: number;
   fill_status: 'AVAILABLE' | 'FILLING' | 'NEARLY_FULL' | 'FULL';
+  /** Scaled-up occupancy estimate based on penetration rate */
+  estimated_occupancy: number;
+  /** Spots available based on estimated occupancy */
+  estimated_available: number;
+  /** The raw device count before scaling (same as current_occupancy) */
+  raw_occupancy: number;
+  /** Effective penetration rate used for this estimate (0.01–1.0) */
+  effective_penetration_rate: number;
 }
 
 export interface GetLotsQueryParams {

--- a/apps/backend/src/lots/lots.module.ts
+++ b/apps/backend/src/lots/lots.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { LotsController } from './lots.controller';
 import { LotsService } from './lots.service';
+import { PenetrationEstimationService } from './penetration-estimation.service';
 
 @Module({
   controllers: [LotsController],
-  providers: [LotsService],
-  exports: [LotsService],
+  providers: [LotsService, PenetrationEstimationService],
+  exports: [LotsService, PenetrationEstimationService],
 })
 export class LotsModule {}

--- a/apps/backend/src/lots/lots.service.spec.ts
+++ b/apps/backend/src/lots/lots.service.spec.ts
@@ -116,6 +116,15 @@ describe('LotsService', () => {
       expect(result[0].lot_id).toBe('G1');
     });
 
+    it('should filter by min_available after estimation', async () => {
+      const smallLot = { ...mockLot, id: 'uuid-small', lot_id: 'G3', capacity: 100, current_occupancy: 80 };
+      // G1: available = 50, G3: available = 20
+      prisma.lot.findMany.mockResolvedValue([mockLot, smallLot]);
+      const result = await service.findAll({ min_available: 30 });
+      expect(result).toHaveLength(1);
+      expect(result[0].lot_id).toBe('G1');
+    });
+
     it('should throw InternalServerErrorException on error', async () => {
       prisma.lot.findMany.mockRejectedValue(new Error('DB error'));
       await expect(service.findAll()).rejects.toThrow(InternalServerErrorException);
@@ -142,6 +151,59 @@ describe('LotsService', () => {
       prisma.lot.findFirst.mockResolvedValue(null);
       await expect(service.findOne('INVALID')).rejects.toThrow(NotFoundException);
     });
+
+    it('should throw InternalServerErrorException on non-NotFoundException', async () => {
+      prisma.lot.findFirst.mockRejectedValue(new Error('Connection lost'));
+      await expect(service.findOne('G1')).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('getOccupancySummary', () => {
+    it('should calculate totals across all lots', async () => {
+      const lots = [
+        {
+          id: 'uuid-1', lot_id: 'G1', lot_name: 'Lot G1', capacity: 100,
+          current_occupancy: 50, lot_type: 'STUDENT', permit_types: [],
+          daily_permit_allowed: false, ev_charging_stations: 0, school_id: 'school-1',
+          penetration_rate: 0.5, latitude: 33.78, longitude: -118.11,
+          geofence_coordinates: [], created_at: new Date(), updated_at: new Date(),
+        },
+        {
+          id: 'uuid-2', lot_id: 'E7', lot_name: 'Lot E7', capacity: 80,
+          current_occupancy: 30, lot_type: 'EMPLOYEE', permit_types: [],
+          daily_permit_allowed: false, ev_charging_stations: 0, school_id: 'school-1',
+          penetration_rate: 0.5, latitude: 33.78, longitude: -118.11,
+          geofence_coordinates: [], created_at: new Date(), updated_at: new Date(),
+        },
+      ];
+      prisma.lot.findMany.mockResolvedValue(lots);
+
+      const summary = await service.getOccupancySummary();
+
+      expect(summary.total_lots).toBe(2);
+      expect(summary.total_capacity).toBe(180);
+      expect(summary.total_occupied).toBe(80);
+      expect(summary.total_available).toBe(100);
+      expect(summary.overall_occupancy_rate).toBeCloseTo(80 / 180, 2);
+      expect(summary.student_lots.count).toBe(1);
+      expect(summary.student_lots.capacity).toBe(100);
+      expect(summary.student_lots.occupied).toBe(50);
+      expect(summary.employee_lots.count).toBe(1);
+      expect(summary.employee_lots.capacity).toBe(80);
+      expect(summary.employee_lots.occupied).toBe(30);
+    });
+
+    it('should return zero rate when total capacity is zero', async () => {
+      prisma.lot.findMany.mockResolvedValue([]);
+      const summary = await service.getOccupancySummary();
+      expect(summary.total_lots).toBe(0);
+      expect(summary.overall_occupancy_rate).toBe(0);
+    });
+
+    it('should throw InternalServerErrorException on error', async () => {
+      prisma.lot.findMany.mockRejectedValue(new Error('Boom'));
+      await expect(service.getOccupancySummary()).rejects.toThrow(InternalServerErrorException);
+    });
   });
 
   describe('getHistory', () => {
@@ -161,6 +223,11 @@ describe('LotsService', () => {
     it('should throw NotFoundException when lot not found', async () => {
       prisma.lot.findFirst.mockResolvedValue(null);
       await expect(service.getHistory('INVALID', '2026-02-07')).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw InternalServerErrorException on non-NotFoundException', async () => {
+      prisma.lot.findFirst.mockRejectedValue(new Error('Connection lost'));
+      await expect(service.getHistory('G1', '2026-02-07')).rejects.toThrow(InternalServerErrorException);
     });
   });
 

--- a/apps/backend/src/lots/lots.service.spec.ts
+++ b/apps/backend/src/lots/lots.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException, InternalServerErrorException } from '@nestjs/common';
 import { LotsService } from './lots.service';
 import { PrismaService } from '../database/database.module';
+import { PenetrationEstimationService } from './penetration-estimation.service';
 
 describe('LotsService', () => {
   let service: LotsService;
@@ -9,6 +10,21 @@ describe('LotsService', () => {
     lot: { findMany: jest.Mock; findFirst: jest.Mock };
     occupancySnapshot: { findMany: jest.Mock };
   };
+  let penetrationService: {
+    estimateForAllLots: jest.Mock;
+    estimateForLot: jest.Mock;
+  };
+
+  /** Helper: builds a default PenetrationEstimate from a lot's raw values */
+  const makeEstimate = (lot: { current_occupancy: number; capacity: number }) => ({
+    effectiveRate: 1,
+    rawOccupancy: lot.current_occupancy,
+    estimatedOccupancy: lot.current_occupancy,
+    estimatedRate: lot.capacity > 0 ? lot.current_occupancy / lot.capacity : 0,
+    campusDevices: 0,
+    adjustedCommuters: 0,
+    isClosure: false,
+  });
 
   beforeEach(async () => {
     prisma = {
@@ -16,10 +32,22 @@ describe('LotsService', () => {
       occupancySnapshot: { findMany: jest.fn() },
     };
 
+    penetrationService = {
+      estimateForAllLots: jest.fn().mockImplementation(async (lots: any[]) => {
+        const map = new Map();
+        for (const lot of lots) {
+          map.set(lot.id, makeEstimate(lot));
+        }
+        return map;
+      }),
+      estimateForLot: jest.fn().mockImplementation(async (lot: any) => makeEstimate(lot)),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         LotsService,
         { provide: PrismaService, useValue: prisma },
+        { provide: PenetrationEstimationService, useValue: penetrationService },
       ],
     }).compile();
 
@@ -81,7 +109,7 @@ describe('LotsService', () => {
     });
 
     it('should filter by available_only after fetch', async () => {
-      const fullLot = { ...mockLot, current_occupancy: 100 };
+      const fullLot = { ...mockLot, id: 'uuid-full', lot_id: 'G2', current_occupancy: 100 };
       prisma.lot.findMany.mockResolvedValue([mockLot, fullLot]);
       const result = await service.findAll({ available_only: true });
       expect(result).toHaveLength(1);

--- a/apps/backend/src/lots/lots.service.spec.ts
+++ b/apps/backend/src/lots/lots.service.spec.ts
@@ -17,7 +17,6 @@ describe('LotsService', () => {
 
   /** Helper: builds a default PenetrationEstimate from a lot's raw values */
   const makeEstimate = (lot: { current_occupancy: number; capacity: number }) => ({
-    effectiveRate: 1,
     rawOccupancy: lot.current_occupancy,
     estimatedOccupancy: lot.current_occupancy,
     estimatedRate: lot.capacity > 0 ? lot.current_occupancy / lot.capacity : 0,

--- a/apps/backend/src/lots/lots.service.ts
+++ b/apps/backend/src/lots/lots.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException, InternalServerErrorException, Logger } f
 import { PrismaService } from '../database/database.module';
 import type { Lot, LotType } from '@prisma/client';
 import type { ParkingLotResponse, GetLotsQueryParams, OccupancySnapshotResponse, LotRecommendation } from './interfaces/parking-lot.interface';
+import { PenetrationEstimationService, PenetrationEstimate } from './penetration-estimation.service';
 
 /**
  * Service for parking lot data access and business logic.
@@ -11,7 +12,10 @@ import type { ParkingLotResponse, GetLotsQueryParams, OccupancySnapshotResponse,
 export class LotsService {
   private readonly logger = new Logger(LotsService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly penetrationService: PenetrationEstimationService,
+  ) {}
 
   /**
    * Retrieves all parking lots, with optional filtering.
@@ -28,22 +32,22 @@ export class LotsService {
         },
       });
 
-      let filteredLots = lots;
+      // Batch-estimate penetration for all lots at once (single set of DB queries)
+      const estimates = await this.penetrationService.estimateForAllLots(lots);
 
-      // These filters require computed values, so apply after fetch
+      // Transform to responses first so filters can use estimated values
+      let responses = lots.map(lot => this.transformToResponse(lot, estimates.get(lot.id)));
+
+      // Post-estimation filters — use estimated availability for accuracy
       if (query.min_available) {
-        filteredLots = filteredLots.filter(lot =>
-          (lot.capacity - lot.current_occupancy) >= query.min_available!
-        );
+        responses = responses.filter(r => r.estimated_available >= query.min_available!);
       }
 
       if (query.available_only) {
-        filteredLots = filteredLots.filter(lot =>
-          lot.current_occupancy < lot.capacity
-        );
+        responses = responses.filter(r => r.estimated_available > 0);
       }
 
-      return filteredLots.map(lot => this.transformToResponse(lot));
+      return responses;
     } catch (error) {
       this.logger.error('Failed to fetch parking lots', error);
       throw new InternalServerErrorException('Failed to fetch parking lots');
@@ -60,7 +64,7 @@ export class LotsService {
         throw new NotFoundException(`Parking lot ${lotId} not found`);
       }
 
-      return this.transformToResponse(lot);
+      return this.transformToResponse(lot, await this.penetrationService.estimateForLot(lot));
     } catch (error) {
       if (error instanceof NotFoundException) {
         throw error;
@@ -130,7 +134,7 @@ export class LotsService {
       const employeeLots = lots.filter(lot => lot.lot_type === 'EMPLOYEE');
 
       const totalCapacity = lots.reduce((sum, lot) => sum + lot.capacity, 0);
-      const totalOccupied = lots.reduce((sum, lot) => sum + lot.current_occupancy, 0);
+      const totalOccupied = lots.reduce((sum, lot) => sum + lot.estimated_occupancy, 0);
 
       return {
         total_lots: lots.length,
@@ -141,12 +145,12 @@ export class LotsService {
         student_lots: {
           count: studentLots.length,
           capacity: studentLots.reduce((sum, lot) => sum + lot.capacity, 0),
-          occupied: studentLots.reduce((sum, lot) => sum + lot.current_occupancy, 0),
+          occupied: studentLots.reduce((sum, lot) => sum + lot.estimated_occupancy, 0),
         },
         employee_lots: {
           count: employeeLots.length,
           capacity: employeeLots.reduce((sum, lot) => sum + lot.capacity, 0),
-          occupied: employeeLots.reduce((sum, lot) => sum + lot.current_occupancy, 0),
+          occupied: employeeLots.reduce((sum, lot) => sum + lot.estimated_occupancy, 0),
         },
       };
     } catch (error) {
@@ -191,18 +195,22 @@ export class LotsService {
       },
     });
 
+    // Batch-estimate penetration for all candidates
+    const estimates = await this.penetrationService.estimateForAllLots(candidates);
+
     const W = LotsService.RECOMMENDATION_WEIGHTS;
 
     const scored = candidates
       .map(candidate => {
-        const response = this.transformToResponse(candidate);
+        const estimate = estimates.get(candidate.id);
+        const response = this.transformToResponse(candidate, estimate);
 
-        // Skip lots that are full
+        // Skip lots that are full (based on estimated occupancy)
         if (response.occupancy_rate >= LotsService.FULL_THRESHOLD) return null;
 
         // --- Availability score (0–1): higher = more space available ---
         const availabilityScore = candidate.capacity > 0
-          ? (candidate.capacity - candidate.current_occupancy) / candidate.capacity
+          ? response.estimated_available / candidate.capacity
           : 0;
 
         // --- Distance score (0–1): closer = higher ---
@@ -290,10 +298,17 @@ export class LotsService {
 
   /**
    * Adds computed fields to parking lot data for client consumption.
+   * When a PenetrationEstimate is provided, uses estimated occupancy for
+   * availability, occupancy_rate, and fill_status calculations.
    */
-  private transformToResponse(lot: Lot): ParkingLotResponse {
-    const available = lot.capacity - lot.current_occupancy;
-    const occupancy_rate = lot.capacity > 0 ? lot.current_occupancy / lot.capacity : 0;
+  private transformToResponse(lot: Lot, estimate?: PenetrationEstimate): ParkingLotResponse {
+    const rawOccupancy = lot.current_occupancy;
+    const estimatedOccupancy = estimate ? estimate.estimatedOccupancy : rawOccupancy;
+
+    // `available` uses estimated occupancy — represents the best-guess true availability.
+    // `estimated_available` is an explicit alias; both use the same estimated value.
+    const available = lot.capacity - estimatedOccupancy;
+    const occupancy_rate = lot.capacity > 0 ? estimatedOccupancy / lot.capacity : 0;
 
     let fill_status: 'AVAILABLE' | 'FILLING' | 'NEARLY_FULL' | 'FULL';
     if (occupancy_rate >= 0.95) {
@@ -308,9 +323,15 @@ export class LotsService {
 
     return {
       ...lot,
-      available,
+      available: Math.max(0, available),
       occupancy_rate: Math.round(occupancy_rate * 1000) / 1000,
       fill_status,
+      estimated_occupancy: estimatedOccupancy,
+      estimated_available: Math.max(0, available),
+      raw_occupancy: rawOccupancy,
+      effective_penetration_rate: estimate
+        ? Math.round(estimate.effectiveRate * 10000) / 10000
+        : 1,
     };
   }
 }

--- a/apps/backend/src/lots/penetration-estimation.service.spec.ts
+++ b/apps/backend/src/lots/penetration-estimation.service.spec.ts
@@ -1,0 +1,554 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PenetrationEstimationService } from './penetration-estimation.service';
+import { PrismaService } from '../database/database.module';
+import type { Lot } from '@prisma/client';
+
+// ─── Helpers ─────────────────────────────────────────────
+
+/** Creates a Date for a specific day/time in local timezone */
+const dateAt = (year: number, month: number, day: number, hour = 10, minute = 0): Date =>
+  new Date(year, month - 1, day, hour, minute, 0, 0);
+
+/** Tuesday, March 10 2026, 10:00 AM — a normal weekday peak time */
+const WEEKDAY_PEAK = dateAt(2026, 3, 10, 10, 0);
+
+/** Tuesday, March 10 2026, 8:00 PM — weekday evening */
+const WEEKDAY_EVENING = dateAt(2026, 3, 10, 20, 0);
+
+/** Tuesday, March 10 2026, 2:00 AM — weekday night */
+const WEEKDAY_NIGHT = dateAt(2026, 3, 10, 2, 0);
+
+/** Saturday, March 14 2026, 12:00 PM — Saturday day */
+const SATURDAY_DAY = dateAt(2026, 3, 14, 12, 0);
+
+/** Saturday, March 14 2026, 8:00 PM — Saturday off-peak */
+const SATURDAY_NIGHT = dateAt(2026, 3, 14, 20, 0);
+
+/** Sunday, March 15 2026, 12:00 PM */
+const SUNDAY = dateAt(2026, 3, 15, 12, 0);
+
+const makeLot = (overrides: Partial<Lot> = {}): Lot => ({
+  id: 'lot-1',
+  lot_id: 'G1',
+  lot_name: 'Lot G1',
+  display_name: 'Lot G1',
+  lot_number: '1',
+  capacity: 1000,
+  current_occupancy: 100,
+  lot_type: 'STUDENT',
+  location_description: 'Near Science Building',
+  building_proximity: ['Science'],
+  center_lat: 33.78,
+  center_lng: -118.11,
+  geofence_polygon: [],
+  geofence_radius: 100,
+  permit_types: ['Gold'],
+  daily_permit_allowed: true,
+  daily_rate: null,
+  hours_weekday: { open: '06:00', close: '22:00' },
+  hours_saturday: { open: '06:00', close: '22:00' },
+  hours_sunday: { open: '06:00', close: '22:00' },
+  ev_charging_stations: 2,
+  motorcycle_spaces: 0,
+  accessible_spaces: 5,
+  has_lighting: true,
+  has_cameras: false,
+  has_emergency_phone: false,
+  is_covered: false,
+  is_paved: true,
+  levels: null,
+  school_id: 'school-1',
+  penetration_rate: 0.01,
+  avg_turnover_minutes: 0,
+  confidence: 'LOW',
+  created_at: new Date(),
+  updated_at: new Date(),
+  ...overrides,
+} as Lot);
+
+// ─── Tests ───────────────────────────────────────────────
+
+describe('PenetrationEstimationService', () => {
+  let service: PenetrationEstimationService;
+  let prisma: {
+    academicCalendar: { findFirst: jest.Mock };
+    campusClosure: { findFirst: jest.Mock };
+    school: { findUnique: jest.Mock };
+    $queryRaw: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      academicCalendar: { findFirst: jest.fn().mockResolvedValue(null) },
+      campusClosure: { findFirst: jest.fn().mockResolvedValue(null) },
+      school: { findUnique: jest.fn().mockResolvedValue({ timezone: 'UTC' }) },
+      $queryRaw: jest.fn().mockResolvedValue([{ count: BigInt(0) }]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PenetrationEstimationService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<PenetrationEstimationService>(PenetrationEstimationService);
+    jest.clearAllMocks();
+    // Default spy — makes toSchoolTime a no-op so local-time test dates
+    // pass through directly to getTimeMultiplier.
+    jest.spyOn(service, 'toSchoolTime').mockImplementation((date: Date) => date);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ─── computeFloor ─────────────────────────────────────
+
+  describe('computeFloor', () => {
+    it('returns 15% of capacity at weekday peak', () => {
+      // floor(1000 × 0.15 × 1.0) = 150
+      expect(service.computeFloor(1000, 1.0, false)).toBe(150);
+    });
+
+    it('scales floor by time multiplier', () => {
+      // floor(1000 × 0.15 × 0.35) = 52  (weekday evening)
+      expect(service.computeFloor(1000, 0.35, false)).toBe(52);
+    });
+
+    it('scales floor by Saturday day multiplier', () => {
+      // floor(1000 × 0.15 × 0.15) = 22
+      expect(service.computeFloor(1000, 0.15, false)).toBe(22);
+    });
+
+    it('returns 0 when time multiplier is below threshold', () => {
+      // 0.05 < 0.10 threshold → no floor
+      expect(service.computeFloor(1000, 0.05, false)).toBe(0);
+    });
+
+    it('returns 0 during campus closure regardless of time', () => {
+      expect(service.computeFloor(1000, 1.0, true)).toBe(0);
+    });
+
+    it('scales proportionally to lot capacity', () => {
+      // 500-space lot: floor(500 × 0.15 × 1.0) = 75
+      expect(service.computeFloor(500, 1.0, false)).toBe(75);
+      // 200-space lot: floor(200 × 0.15 × 1.0) = 30
+      expect(service.computeFloor(200, 1.0, false)).toBe(30);
+    });
+  });
+
+  // ─── getTimeMultiplier ────────────────────────────────
+
+  describe('getTimeMultiplier', () => {
+    it('returns 1.0 for weekday peak (7 AM – 6 PM)', () => {
+      expect(service.getTimeMultiplier(WEEKDAY_PEAK)).toBe(1.0);
+    });
+
+    it('returns 0.35 for weekday evening (6 PM – 10 PM)', () => {
+      expect(service.getTimeMultiplier(WEEKDAY_EVENING)).toBe(0.35);
+    });
+
+    it('returns 0.05 for weekday night (10 PM – 7 AM)', () => {
+      expect(service.getTimeMultiplier(WEEKDAY_NIGHT)).toBe(0.05);
+    });
+
+    it('returns 0.15 for Saturday daytime (8 AM – 6 PM)', () => {
+      expect(service.getTimeMultiplier(SATURDAY_DAY)).toBe(0.15);
+    });
+
+    it('returns 0.05 for Saturday off-peak', () => {
+      expect(service.getTimeMultiplier(SATURDAY_NIGHT)).toBe(0.05);
+    });
+
+    it('returns 0.05 for Sunday', () => {
+      expect(service.getTimeMultiplier(SUNDAY)).toBe(0.05);
+    });
+
+    it('returns 1.0 for weekday 7 AM boundary', () => {
+      expect(service.getTimeMultiplier(dateAt(2026, 3, 10, 7, 0))).toBe(1.0);
+    });
+
+    it('returns 0.35 for weekday 6 PM boundary', () => {
+      expect(service.getTimeMultiplier(dateAt(2026, 3, 10, 18, 0))).toBe(0.35);
+    });
+
+    it('returns 0.05 for weekday 10 PM boundary', () => {
+      expect(service.getTimeMultiplier(dateAt(2026, 3, 10, 22, 0))).toBe(0.05);
+    });
+  });
+
+  // ─── getMaxScaling ────────────────────────────────────
+
+  describe('getMaxScaling', () => {
+    it('returns Infinity for 500+ devices', () => {
+      expect(service.getMaxScaling(500)).toBe(Infinity);
+      expect(service.getMaxScaling(1000)).toBe(Infinity);
+    });
+
+    it('returns 10 for 200–499 devices', () => {
+      expect(service.getMaxScaling(200)).toBe(10);
+      expect(service.getMaxScaling(499)).toBe(10);
+    });
+
+    it('returns 5 for 50–199 devices', () => {
+      expect(service.getMaxScaling(50)).toBe(5);
+      expect(service.getMaxScaling(199)).toBe(5);
+    });
+
+    it('returns 2 for < 50 devices', () => {
+      expect(service.getMaxScaling(0)).toBe(2);
+      expect(service.getMaxScaling(49)).toBe(2);
+    });
+  });
+
+  // ─── getExpectedCommuters ─────────────────────────────
+
+  describe('getExpectedCommuters', () => {
+    it('returns commuters from matching academic period', async () => {
+      prisma.academicCalendar.findFirst.mockResolvedValue({
+        period_name: 'Spring 2026',
+        expected_commuters: 34_000,
+      });
+
+      const result = await service.getExpectedCommuters('school-1', WEEKDAY_PEAK);
+      expect(result).toBe(34_000);
+    });
+
+    it('falls back to most recent period when no match', async () => {
+      prisma.academicCalendar.findFirst
+        .mockResolvedValueOnce(null) // no matching period
+        .mockResolvedValueOnce({ period_name: 'Fall 2025', expected_commuters: 35_000 }); // most recent
+
+      const result = await service.getExpectedCommuters('school-1', WEEKDAY_PEAK);
+      expect(result).toBe(35_000);
+    });
+
+    it('returns DEFAULT_COMMUTERS (35000) when no calendar data', async () => {
+      prisma.academicCalendar.findFirst.mockResolvedValue(null);
+
+      const result = await service.getExpectedCommuters('school-1', WEEKDAY_PEAK);
+      expect(result).toBe(35_000);
+    });
+  });
+
+  // ─── isCampusClosure ──────────────────────────────────
+
+  describe('isCampusClosure', () => {
+    it('returns true when a closure exists for the date', async () => {
+      prisma.campusClosure.findFirst.mockResolvedValue({ reason: 'MLK Day' });
+      const result = await service.isCampusClosure('school-1', WEEKDAY_PEAK);
+      expect(result).toBe(true);
+    });
+
+    it('returns false when no closure exists', async () => {
+      prisma.campusClosure.findFirst.mockResolvedValue(null);
+      const result = await service.isCampusClosure('school-1', WEEKDAY_PEAK);
+      expect(result).toBe(false);
+    });
+  });
+
+  // ─── countCampusDevices ───────────────────────────────
+
+  describe('countCampusDevices', () => {
+    it('returns the distinct device count from raw SQL', async () => {
+      (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ count: BigInt(3) }]);
+      const result = await service.countCampusDevices('school-1', WEEKDAY_PEAK);
+      expect(result).toBe(3);
+    });
+
+    it('returns 0 when query returns zero', async () => {
+      (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ count: BigInt(0) }]);
+      const result = await service.countCampusDevices('school-1', WEEKDAY_PEAK);
+      expect(result).toBe(0);
+    });
+
+    it('returns 0 when query returns no rows', async () => {
+      (prisma.$queryRaw as jest.Mock).mockResolvedValue([]);
+      const result = await service.countCampusDevices('school-1', WEEKDAY_PEAK);
+      expect(result).toBe(0);
+    });
+  });
+
+  // ─── getSchoolTimezone ────────────────────────────────
+
+  describe('getSchoolTimezone', () => {
+    it('returns timezone from school record', async () => {
+      prisma.school.findUnique.mockResolvedValue({ timezone: 'America/New_York' });
+      const result = await service.getSchoolTimezone('school-1');
+      expect(result).toBe('America/New_York');
+    });
+
+    it('falls back to America/Los_Angeles when school not found', async () => {
+      prisma.school.findUnique.mockResolvedValue(null);
+      const result = await service.getSchoolTimezone('school-1');
+      expect(result).toBe('America/Los_Angeles');
+    });
+  });
+
+  // ─── toSchoolTime ─────────────────────────────────────
+
+  describe('toSchoolTime', () => {
+    beforeEach(() => {
+      // Restore the real implementation for this describe block
+      (service.toSchoolTime as jest.MockedFunction<typeof service.toSchoolTime>).mockRestore();
+    });
+
+    it('converts UTC date to school timezone', () => {
+      // 2026-03-10T17:00:00Z in America/Los_Angeles (PDT, UTC-7) = 10:00 AM
+      const utc = new Date(Date.UTC(2026, 2, 10, 17, 0));
+      const result = service.toSchoolTime(utc, 'America/Los_Angeles');
+      expect(result.getHours()).toBe(10);
+      expect(result.getDay()).toBe(2); // Tuesday
+    });
+
+    it('handles UTC timezone as identity', () => {
+      const utc = new Date(Date.UTC(2026, 2, 10, 15, 0));
+      const result = service.toSchoolTime(utc, 'UTC');
+      expect(result.getHours()).toBe(15);
+    });
+  });
+
+  // ─── estimateForLot ───────────────────────────────────
+
+  describe('estimateForLot', () => {
+    const setupMocks = (opts: {
+      commuters?: number;
+      closure?: boolean;
+      campusDeviceCount?: number;
+    } = {}) => {
+      const { commuters = 35_000, closure = false, campusDeviceCount = 0 } = opts;
+
+      prisma.academicCalendar.findFirst.mockResolvedValue({
+        period_name: 'Spring 2026',
+        expected_commuters: commuters,
+      });
+      prisma.campusClosure.findFirst.mockResolvedValue(closure ? { reason: 'Holiday' } : null);
+      (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ count: BigInt(campusDeviceCount) }]);
+    };
+
+    it('returns floor estimate when lot has zero occupancy during peak hours', async () => {
+      setupMocks({ commuters: 35_000 });
+      const lot = makeLot({ current_occupancy: 0, capacity: 1000 });
+      const result = await service.estimateForLot(lot, WEEKDAY_PEAK);
+
+      // floor = floor(1000 × 0.15 × 1.0) = 150
+      expect(result.rawOccupancy).toBe(0);
+      expect(result.estimatedOccupancy).toBe(150);
+      expect(result.estimatedRate).toBe(0.15);
+      expect(result.effectiveRate).toBe(1);
+      expect(result.isClosure).toBe(false);
+    });
+
+    it('returns zero when lot has zero occupancy during nighttime', async () => {
+      setupMocks({ commuters: 35_000 });
+      const lot = makeLot({ current_occupancy: 0, capacity: 1000 });
+      const result = await service.estimateForLot(lot, WEEKDAY_NIGHT);
+
+      // timeMultiplier 0.05 < threshold 0.10 → no floor
+      expect(result.rawOccupancy).toBe(0);
+      expect(result.estimatedOccupancy).toBe(0);
+      expect(result.effectiveRate).toBe(1);
+    });
+
+    it('returns zero when lot has zero occupancy during closure', async () => {
+      setupMocks({ commuters: 35_000, closure: true });
+      const lot = makeLot({ current_occupancy: 0, capacity: 1000 });
+      const result = await service.estimateForLot(lot, WEEKDAY_PEAK);
+
+      // closure → no floor applied
+      expect(result.rawOccupancy).toBe(0);
+      expect(result.estimatedOccupancy).toBe(0);
+      expect(result.effectiveRate).toBe(1);
+      expect(result.isClosure).toBe(true);
+    });
+
+    it('scales up raw occupancy based on penetration rate during weekday peak', async () => {
+      // 600 campus devices / 35000 commuters = ~0.0171 rate
+      // lot has 100 occupancy, 0.01 pen rate → effective = max(0.0171, 0.01, 0.01) = 0.0171
+      // scaling = 1/0.0171 ≈ 58.3 but cap at Infinity (600 devices > 500)
+      // min(100 * 58.3, 1000) = 1000 (capped at capacity)
+      setupMocks({ commuters: 35_000, campusDeviceCount: 600 });
+
+      const lot = makeLot({ current_occupancy: 100 });
+      const result = await service.estimateForLot(lot, WEEKDAY_PEAK);
+
+      expect(result.rawOccupancy).toBe(100);
+      expect(result.estimatedOccupancy).toBeGreaterThan(100);
+      expect(result.estimatedOccupancy).toBeLessThanOrEqual(1000);
+      expect(result.effectiveRate).toBeGreaterThan(0);
+    });
+
+    it('applies activity cap when few devices are active', async () => {
+      // 30 campus devices → max scaling = 2×
+      // 30/35000 = 0.000857 rate, but scaling capped at 2×
+      // effective rate = max(0.000857, 0.01, 0.01) = 0.01 → scaling 100
+      // capped to 2× → 100 * 2 = 200
+      setupMocks({ commuters: 35_000, campusDeviceCount: 30 });
+
+      const lot = makeLot({ current_occupancy: 100 });
+      const result = await service.estimateForLot(lot, WEEKDAY_PEAK);
+
+      expect(result.estimatedOccupancy).toBe(200); // 100 * 2 cap
+    });
+
+    it('never exceeds lot capacity', async () => {
+      setupMocks({ commuters: 35_000, campusDeviceCount: 600 });
+
+      const lot = makeLot({ current_occupancy: 900, capacity: 1000 });
+      const result = await service.estimateForLot(lot, WEEKDAY_PEAK);
+
+      expect(result.estimatedOccupancy).toBeLessThanOrEqual(1000);
+    });
+
+    it('never drops below raw occupancy', async () => {
+      // Even with a very high penetration rate (e.g. lot pen rate = 1.0)
+      setupMocks();
+
+      const lot = makeLot({ current_occupancy: 100, penetration_rate: 1.0 });
+      const result = await service.estimateForLot(lot, WEEKDAY_PEAK);
+
+      expect(result.estimatedOccupancy).toBeGreaterThanOrEqual(100);
+    });
+
+    it('applies closure multiplier during campus closure', async () => {
+      // During closure: timeMultiplier = 0.02
+      // adjustedCommuters = round(35000 * 0.02) = 700
+      // 200 campus devices / 700 = 0.2857 rate
+      // effective = max(0.2857, 0.01, 0.01) = 0.2857
+      // scaling = 1/0.2857 = 3.5, capped at 5 (200 devices)
+      // estimatedOccupancy = round(100 * 3.5) = 350
+      setupMocks({ commuters: 35_000, closure: true, campusDeviceCount: 200 });
+
+      const lot = makeLot({ current_occupancy: 100 });
+      const result = await service.estimateForLot(lot, WEEKDAY_PEAK);
+
+      expect(result.estimatedOccupancy).toBe(350);
+    });
+
+    it('rounds effectiveRate to 4 decimal places', async () => {
+      setupMocks({ commuters: 35_000, campusDeviceCount: 100 });
+
+      const lot = makeLot({ current_occupancy: 50 });
+      const result = await service.estimateForLot(lot, WEEKDAY_PEAK);
+
+      // effectiveRate should have at most 4 decimal places
+      const decimalStr = result.effectiveRate.toString().split('.')[1] || '';
+      expect(decimalStr.length).toBeLessThanOrEqual(4);
+    });
+
+    it('uses lot penetration_rate when it is higher than campus rate', async () => {
+      // 100 campus devices / 35000 = 0.00286 campus rate
+      // lot penetration_rate = 0.5 → effective = max(0.00286, 0.5, 0.01) = 0.5
+      // scaling = 1/0.5 = 2, capped at 5 (100 devices)
+      // estimatedOccupancy = round(100 * 2) = 200
+      setupMocks({ commuters: 35_000, campusDeviceCount: 100 });
+
+      const lot = makeLot({ current_occupancy: 100, penetration_rate: 0.5 });
+      const result = await service.estimateForLot(lot, WEEKDAY_PEAK);
+
+      expect(result.effectiveRate).toBe(0.5);
+      expect(result.estimatedOccupancy).toBe(200);
+    });
+
+    it('reduces estimated occupancy during weekend', async () => {
+      // Saturday day: timeMultiplier = 0.15
+      // adjustedCommuters = round(35000 * 0.15) = 5250
+      // 100 devices / 5250 = 0.01905
+      // effective = max(0.01905, 0.01, 0.01) = 0.01905
+      // scaling = 1/0.01905 = 52.5, capped at 5 (100 devices)
+      // estimatedOccupancy = round(100 * 5) = 500
+      setupMocks({ commuters: 35_000, campusDeviceCount: 100 });
+
+      const lot = makeLot({ current_occupancy: 100 });
+      const result = await service.estimateForLot(lot, SATURDAY_DAY);
+
+      expect(result.estimatedOccupancy).toBe(500);
+    });
+
+    it('uses MIN_PENETRATION_RATE when all rates are very low', async () => {
+      // 0 campus devices → campusRate = 0, lot pen = 0.005
+      // effective = max(0, 0.005, 0.01) = 0.01
+      // scaling = 100, capped at 2 (0 devices)
+      // estimatedOccupancy = min(100 * 2, 1000) = 200
+      setupMocks();
+
+      const lot = makeLot({ current_occupancy: 100, penetration_rate: 0.005 });
+      const result = await service.estimateForLot(lot, WEEKDAY_PEAK);
+
+      expect(result.effectiveRate).toBe(0.01);
+      expect(result.estimatedOccupancy).toBe(200); // capped at 2× with 0 devices
+    });
+  });
+
+  // ─── estimateForAllLots ───────────────────────────────
+
+  describe('estimateForAllLots', () => {
+    it('returns empty map for empty lot list', async () => {
+      const result = await service.estimateForAllLots([], WEEKDAY_PEAK);
+      expect(result.size).toBe(0);
+    });
+
+    it('estimates for multiple lots sharing campus-wide data', async () => {
+      prisma.academicCalendar.findFirst.mockResolvedValue({
+        period_name: 'Spring 2026',
+        expected_commuters: 35_000,
+      });
+      prisma.campusClosure.findFirst.mockResolvedValue(null);
+      (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ count: BigInt(100) }]);
+
+      const lots = [
+        makeLot({ id: 'lot-1', current_occupancy: 100, capacity: 1000 }),
+        makeLot({ id: 'lot-2', current_occupancy: 50, capacity: 500 }),
+      ];
+
+      const result = await service.estimateForAllLots(lots, WEEKDAY_PEAK);
+
+      expect(result.size).toBe(2);
+      expect(result.get('lot-1')).toBeDefined();
+      expect(result.get('lot-2')).toBeDefined();
+
+      // Both should share the same campus device count
+      expect(result.get('lot-1')!.campusDevices).toBe(100);
+      expect(result.get('lot-2')!.campusDevices).toBe(100);
+    });
+
+    it('applies floor for lots with zero occupancy during peak', async () => {
+      prisma.academicCalendar.findFirst.mockResolvedValue({
+        period_name: 'Spring 2026',
+        expected_commuters: 35_000,
+      });
+      prisma.campusClosure.findFirst.mockResolvedValue(null);
+      (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ count: BigInt(0) }]);
+
+      const lots = [makeLot({ current_occupancy: 0, capacity: 1000 })];
+      const result = await service.estimateForAllLots(lots, WEEKDAY_PEAK);
+
+      const estimate = result.get('lot-1')!;
+      expect(estimate.rawOccupancy).toBe(0);
+      // floor = floor(1000 × 0.15 × 1.0) = 150
+      expect(estimate.estimatedOccupancy).toBe(150);
+      expect(estimate.effectiveRate).toBe(1);
+      expect(estimate.isClosure).toBe(false);
+    });
+
+    it('queries academic calendar only once for the batch', async () => {
+      prisma.academicCalendar.findFirst.mockResolvedValue({
+        period_name: 'Spring 2026',
+        expected_commuters: 35_000,
+      });
+      prisma.campusClosure.findFirst.mockResolvedValue(null);
+      (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ count: BigInt(0) }]);
+
+      const lots = [
+        makeLot({ id: 'lot-1', current_occupancy: 10 }),
+        makeLot({ id: 'lot-2', current_occupancy: 20 }),
+      ];
+
+      await service.estimateForAllLots(lots, WEEKDAY_PEAK);
+
+      // Academic calendar should be queried once (not once per lot)
+      expect(prisma.academicCalendar.findFirst).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/backend/src/lots/penetration-estimation.service.spec.ts
+++ b/apps/backend/src/lots/penetration-estimation.service.spec.ts
@@ -71,16 +71,12 @@ const makeLot = (overrides: Partial<Lot> = {}): Lot => ({
 describe('PenetrationEstimationService', () => {
   let service: PenetrationEstimationService;
   let prisma: {
-    academicCalendar: { findFirst: jest.Mock };
-    campusClosure: { findFirst: jest.Mock };
     school: { findUnique: jest.Mock };
     $queryRaw: jest.Mock;
   };
 
   beforeEach(async () => {
     prisma = {
-      academicCalendar: { findFirst: jest.fn().mockResolvedValue(null) },
-      campusClosure: { findFirst: jest.fn().mockResolvedValue(null) },
       school: { findUnique: jest.fn().mockResolvedValue({ timezone: 'UTC' }) },
       $queryRaw: jest.fn().mockResolvedValue([{ count: BigInt(0) }]),
     };
@@ -97,6 +93,9 @@ describe('PenetrationEstimationService', () => {
     // Default spy — makes toSchoolTime a no-op so local-time test dates
     // pass through directly to getTimeMultiplier.
     jest.spyOn(service, 'toSchoolTime').mockImplementation((date: Date) => date);
+    // Default spies for calendar-based methods — allow tests to control values
+    jest.spyOn(service, 'getExpectedCommuters').mockReturnValue(35_000);
+    jest.spyOn(service, 'isCampusClosure').mockReturnValue(false);
   });
 
   it('should be defined', () => {
@@ -202,49 +201,61 @@ describe('PenetrationEstimationService', () => {
     });
   });
 
-  // ─── getExpectedCommuters ─────────────────────────────
+  // ─── getExpectedCommuters (delegates to academic calendar module) ────
 
   describe('getExpectedCommuters', () => {
-    it('returns commuters from matching academic period', async () => {
-      prisma.academicCalendar.findFirst.mockResolvedValue({
-        period_name: 'Spring 2026',
-        expected_commuters: 34_000,
-      });
-
-      const result = await service.getExpectedCommuters('school-1', WEEKDAY_PEAK);
-      expect(result).toBe(34_000);
+    beforeEach(() => {
+      // Restore the real implementation for this describe block
+      (service.getExpectedCommuters as jest.Mock).mockRestore();
     });
 
-    it('falls back to most recent period when no match', async () => {
-      prisma.academicCalendar.findFirst
-        .mockResolvedValueOnce(null) // no matching period
-        .mockResolvedValueOnce({ period_name: 'Fall 2025', expected_commuters: 35_000 }); // most recent
-
-      const result = await service.getExpectedCommuters('school-1', WEEKDAY_PEAK);
-      expect(result).toBe(35_000);
+    it('returns spring commuters for a weekday in Spring semester', () => {
+      // March 10, 2026 is during Spring 2026
+      expect(service.getExpectedCommuters(WEEKDAY_PEAK)).toBe(34_000);
     });
 
-    it('returns DEFAULT_COMMUTERS (35000) when no calendar data', async () => {
-      prisma.academicCalendar.findFirst.mockResolvedValue(null);
+    it('returns fall commuters for a weekday in Fall semester', () => {
+      // October 15, 2025 is during Fall 2025
+      expect(service.getExpectedCommuters(dateAt(2025, 10, 15, 10, 0))).toBe(35_000);
+    });
 
-      const result = await service.getExpectedCommuters('school-1', WEEKDAY_PEAK);
-      expect(result).toBe(35_000);
+    it('returns break commuters for a date between semesters', () => {
+      // December 30, 2025 is between Fall and Winter session
+      expect(service.getExpectedCommuters(dateAt(2025, 12, 30, 10, 0))).toBe(1_500);
+    });
+
+    it('returns break commuters for a campus-closed holiday', () => {
+      // MLK Day 2026 = Jan 19 (campus closed)
+      expect(service.getExpectedCommuters(dateAt(2026, 1, 19, 10, 0))).toBe(1_500);
+    });
+
+    it('returns reduced commuters for in-semester break', () => {
+      // Spring Recess 2026: Mar 30 (campus open, no classes) → 10% of Spring
+      expect(service.getExpectedCommuters(dateAt(2026, 3, 30, 10, 0))).toBe(3_400);
     });
   });
 
-  // ─── isCampusClosure ──────────────────────────────────
+  // ─── isCampusClosure (delegates to academic calendar module) ────
 
   describe('isCampusClosure', () => {
-    it('returns true when a closure exists for the date', async () => {
-      prisma.campusClosure.findFirst.mockResolvedValue({ reason: 'MLK Day' });
-      const result = await service.isCampusClosure('school-1', WEEKDAY_PEAK);
-      expect(result).toBe(true);
+    beforeEach(() => {
+      (service.isCampusClosure as jest.Mock).mockRestore();
     });
 
-    it('returns false when no closure exists', async () => {
-      prisma.campusClosure.findFirst.mockResolvedValue(null);
-      const result = await service.isCampusClosure('school-1', WEEKDAY_PEAK);
-      expect(result).toBe(false);
+    it('returns true for MLK Day', () => {
+      expect(service.isCampusClosure(dateAt(2026, 1, 19, 10, 0))).toBe(true);
+    });
+
+    it('returns true for Cesar Chavez Day', () => {
+      expect(service.isCampusClosure(dateAt(2026, 3, 31, 10, 0))).toBe(true);
+    });
+
+    it('returns false for a regular class day', () => {
+      expect(service.isCampusClosure(WEEKDAY_PEAK)).toBe(false);
+    });
+
+    it('returns false for a spring break day (campus open, no classes)', () => {
+      expect(service.isCampusClosure(dateAt(2026, 3, 30, 10, 0))).toBe(false);
     });
   });
 
@@ -319,11 +330,8 @@ describe('PenetrationEstimationService', () => {
     } = {}) => {
       const { commuters = 35_000, closure = false, campusDeviceCount = 0 } = opts;
 
-      prisma.academicCalendar.findFirst.mockResolvedValue({
-        period_name: 'Spring 2026',
-        expected_commuters: commuters,
-      });
-      prisma.campusClosure.findFirst.mockResolvedValue(closure ? { reason: 'Holiday' } : null);
+      (service.getExpectedCommuters as jest.Mock).mockReturnValue(commuters);
+      (service.isCampusClosure as jest.Mock).mockReturnValue(closure);
       (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ count: BigInt(campusDeviceCount) }]);
     };
 
@@ -510,11 +518,6 @@ describe('PenetrationEstimationService', () => {
     });
 
     it('estimates for multiple lots sharing campus-wide data', async () => {
-      prisma.academicCalendar.findFirst.mockResolvedValue({
-        period_name: 'Spring 2026',
-        expected_commuters: 35_000,
-      });
-      prisma.campusClosure.findFirst.mockResolvedValue(null);
       (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ count: BigInt(100) }]);
 
       const lots = [
@@ -534,11 +537,6 @@ describe('PenetrationEstimationService', () => {
     });
 
     it('applies floor for lots with zero occupancy during peak', async () => {
-      prisma.academicCalendar.findFirst.mockResolvedValue({
-        period_name: 'Spring 2026',
-        expected_commuters: 35_000,
-      });
-      prisma.campusClosure.findFirst.mockResolvedValue(null);
       (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ count: BigInt(0) }]);
 
       const lots = [makeLot({ current_occupancy: 0, capacity: 1000 })];
@@ -552,12 +550,7 @@ describe('PenetrationEstimationService', () => {
       expect(estimate.isClosure).toBe(false);
     });
 
-    it('queries academic calendar only once for the batch', async () => {
-      prisma.academicCalendar.findFirst.mockResolvedValue({
-        period_name: 'Spring 2026',
-        expected_commuters: 35_000,
-      });
-      prisma.campusClosure.findFirst.mockResolvedValue(null);
+    it('computes commuters and closure only once for the batch', async () => {
       (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ count: BigInt(0) }]);
 
       const lots = [
@@ -567,16 +560,12 @@ describe('PenetrationEstimationService', () => {
 
       await service.estimateForAllLots(lots, WEEKDAY_PEAK);
 
-      // Academic calendar should be queried once (not once per lot)
-      expect(prisma.academicCalendar.findFirst).toHaveBeenCalledTimes(1);
+      // Calendar methods should be called once (not once per lot)
+      expect(service.getExpectedCommuters).toHaveBeenCalledTimes(1);
+      expect(service.isCampusClosure).toHaveBeenCalledTimes(1);
     });
 
     it('handles zero-capacity lot in batch estimation', async () => {
-      prisma.academicCalendar.findFirst.mockResolvedValue({
-        period_name: 'Spring 2026',
-        expected_commuters: 35_000,
-      });
-      prisma.campusClosure.findFirst.mockResolvedValue(null);
       (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ count: BigInt(0) }]);
 
       const lots = [makeLot({ id: 'lot-zero', current_occupancy: 5, capacity: 0 })];

--- a/apps/backend/src/lots/penetration-estimation.service.spec.ts
+++ b/apps/backend/src/lots/penetration-estimation.service.spec.ts
@@ -479,6 +479,26 @@ describe('PenetrationEstimationService', () => {
       expect(result.effectiveRate).toBe(0.01);
       expect(result.estimatedOccupancy).toBe(200); // capped at 2× with 0 devices
     });
+
+    it('handles zero capacity lot gracefully', async () => {
+      setupMocks({ commuters: 35_000, campusDeviceCount: 100 });
+
+      const lot = makeLot({ current_occupancy: 10, capacity: 0 });
+      const result = await service.estimateForLot(lot, WEEKDAY_PEAK);
+
+      expect(result.estimatedRate).toBe(0);
+      expect(result.estimatedOccupancy).toBe(10); // clamped to max(raw, min(scaled, 0))
+    });
+
+    it('returns zero floor for zero-capacity lot with zero occupancy', async () => {
+      setupMocks({ commuters: 35_000 });
+
+      const lot = makeLot({ current_occupancy: 0, capacity: 0 });
+      const result = await service.estimateForLot(lot, WEEKDAY_PEAK);
+
+      expect(result.estimatedOccupancy).toBe(0);
+      expect(result.estimatedRate).toBe(0);
+    });
   });
 
   // ─── estimateForAllLots ───────────────────────────────
@@ -549,6 +569,22 @@ describe('PenetrationEstimationService', () => {
 
       // Academic calendar should be queried once (not once per lot)
       expect(prisma.academicCalendar.findFirst).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles zero-capacity lot in batch estimation', async () => {
+      prisma.academicCalendar.findFirst.mockResolvedValue({
+        period_name: 'Spring 2026',
+        expected_commuters: 35_000,
+      });
+      prisma.campusClosure.findFirst.mockResolvedValue(null);
+      (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ count: BigInt(0) }]);
+
+      const lots = [makeLot({ id: 'lot-zero', current_occupancy: 5, capacity: 0 })];
+      const result = await service.estimateForAllLots(lots, WEEKDAY_PEAK);
+
+      const estimate = result.get('lot-zero')!;
+      expect(estimate.estimatedRate).toBe(0);
+      expect(estimate.rawOccupancy).toBe(5);
     });
   });
 });

--- a/apps/backend/src/lots/penetration-estimation.service.ts
+++ b/apps/backend/src/lots/penetration-estimation.service.ts
@@ -2,6 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../database/database.module';
 import { Prisma } from '@prisma/client';
 import type { Lot } from '@prisma/client';
+import {
+  getExpectedCommuters as calendarGetExpectedCommuters,
+  isCampusOpen as calendarIsCampusOpen,
+} from './academic-calendar';
 
 // ─── Types ─────────────────────────────────────────────────
 
@@ -29,9 +33,6 @@ const MIN_PENETRATION_RATE = 0.01;
 
 /** How far back to count active devices (milliseconds) */
 const DEVICE_WINDOW_MS = 2 * 60 * 60 * 1000; // 2 hours
-
-/** Fallback commuter count when no academic calendar is seeded */
-const DEFAULT_COMMUTERS = 35_000;
 
 /**
  * Time-of-day multipliers applied to the academic period's expected_commuters.
@@ -103,13 +104,15 @@ export class PenetrationEstimationService {
   async estimateForLot(lot: Lot, now: Date = new Date()): Promise<PenetrationEstimate> {
     const rawOccupancy = lot.current_occupancy;
 
-    // Layer 1: Academic calendar — base expected commuters
-    const baseCommuters = await this.getExpectedCommuters(lot.school_id, now);
-
-    // Layer 2: Time-of-day + campus closure adjustments
+    // Convert to school time for calendar and time-of-day calculations
     const schoolTz = await this.getSchoolTimezone(lot.school_id);
     const schoolTime = this.toSchoolTime(now, schoolTz);
-    const isClosure = await this.isCampusClosure(lot.school_id, now);
+
+    // Layer 1: Academic calendar — base expected commuters
+    const baseCommuters = this.getExpectedCommuters(schoolTime);
+
+    // Layer 2: Time-of-day + campus closure adjustments
+    const isClosure = this.isCampusClosure(schoolTime);
     const timeMultiplier = isClosure ? CLOSURE_MULTIPLIER : this.getTimeMultiplier(schoolTime);
     const adjustedCommuters = Math.max(1, Math.round(baseCommuters * timeMultiplier));
 
@@ -174,15 +177,15 @@ export class PenetrationEstimationService {
     // All lots belong to the same school in our current setup
     const schoolId = lots[0].school_id;
 
-    // Shared queries (run once for the batch)
-    const [baseCommuters, isClosure, campusDevices, schoolTz] = await Promise.all([
-      this.getExpectedCommuters(schoolId, now),
-      this.isCampusClosure(schoolId, now),
+    // Shared queries — DB for devices+timezone; calendar module for the rest
+    const [campusDevices, schoolTz] = await Promise.all([
       this.countCampusDevices(schoolId, now),
       this.getSchoolTimezone(schoolId),
     ]);
 
     const schoolTime = this.toSchoolTime(now, schoolTz);
+    const baseCommuters = this.getExpectedCommuters(schoolTime);
+    const isClosure = this.isCampusClosure(schoolTime);
     const timeMultiplier = isClosure ? CLOSURE_MULTIPLIER : this.getTimeMultiplier(schoolTime);
     const adjustedCommuters = Math.max(1, Math.round(baseCommuters * timeMultiplier));
     const campusRate = campusDevices > 0 ? campusDevices / adjustedCommuters : 0;
@@ -244,37 +247,10 @@ export class PenetrationEstimationService {
 
   /**
    * Returns the expected_commuters for the academic period containing `date`.
-   * Falls back to DEFAULT_COMMUTERS if no matching period exists.
+   * Accepts a school-local Date (call toSchoolTime first).
    */
-  async getExpectedCommuters(schoolId: string, date: Date): Promise<number> {
-    const period = await this.prisma.academicCalendar.findFirst({
-      where: {
-        school_id: schoolId,
-        start_date: { lte: date },
-        end_date: { gte: date },
-      },
-      orderBy: { start_date: 'desc' },
-    });
-
-    if (period) {
-      return period.expected_commuters;
-    }
-
-    // No matching period — try the most recent one as fallback
-    const recent = await this.prisma.academicCalendar.findFirst({
-      where: { school_id: schoolId, end_date: { lt: date } },
-      orderBy: { end_date: 'desc' },
-    });
-
-    if (recent) {
-      this.logger.warn(
-        `No academic period for ${date.toISOString()}. Using most recent: ${recent.period_name} (${recent.expected_commuters} commuters)`,
-      );
-      return recent.expected_commuters;
-    }
-
-    this.logger.warn(`No academic calendar data found. Using default: ${DEFAULT_COMMUTERS}`);
-    return DEFAULT_COMMUTERS;
+  getExpectedCommuters(schoolTime: Date): number {
+    return calendarGetExpectedCommuters(schoolTime);
   }
 
   // ─── Layer 2: Time & Closures ────────────────────────────
@@ -325,20 +301,10 @@ export class PenetrationEstimationService {
 
   /**
    * Checks whether the given date falls on a campus closure.
+   * Accepts a school-local Date (call toSchoolTime first).
    */
-  async isCampusClosure(schoolId: string, date: Date): Promise<boolean> {
-    // Normalize to date-only (midnight UTC)
-    const startOfDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-    const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000 - 1);
-
-    const closure = await this.prisma.campusClosure.findFirst({
-      where: {
-        school_id: schoolId,
-        date: { gte: startOfDay, lte: endOfDay },
-      },
-    });
-
-    return closure !== null;
+  isCampusClosure(schoolTime: Date): boolean {
+    return !calendarIsCampusOpen(schoolTime);
   }
 
   // ─── Layer 3: Activity-Based Cap ─────────────────────────

--- a/apps/backend/src/lots/penetration-estimation.service.ts
+++ b/apps/backend/src/lots/penetration-estimation.service.ts
@@ -1,0 +1,379 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../database/database.module';
+import { Prisma } from '@prisma/client';
+import type { Lot } from '@prisma/client';
+
+// ─── Types ─────────────────────────────────────────────────
+
+export interface PenetrationEstimate {
+  /** Effective penetration rate used for this lot (0.01–1.0) */
+  effectiveRate: number;
+  /** Raw device count (current_occupancy in DB) */
+  rawOccupancy: number;
+  /** Scaled-up estimate clamped to [rawOccupancy, capacity] */
+  estimatedOccupancy: number;
+  /** estimatedOccupancy / capacity */
+  estimatedRate: number;
+  /** Campus-wide active devices in the observation window */
+  campusDevices: number;
+  /** Adjusted expected commuters (after time-of-day + calendar) */
+  adjustedCommuters: number;
+  /** Whether the campus is on a closure day */
+  isClosure: boolean;
+}
+
+// ─── Constants ─────────────────────────────────────────────
+
+/** Hard floor — prevents divide-by-zero and absurd inflation */
+const MIN_PENETRATION_RATE = 0.01;
+
+/** How far back to count active devices (milliseconds) */
+const DEVICE_WINDOW_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+/** Fallback commuter count when no academic calendar is seeded */
+const DEFAULT_COMMUTERS = 35_000;
+
+/**
+ * Time-of-day multipliers applied to the academic period's expected_commuters.
+ * Indexed by (isWeekend, hourBucket).
+ */
+const TIME_MULTIPLIERS: Record<string, number> = {
+  // Weekday
+  'wd_peak':    1.0,   // 7 AM – 6 PM
+  'wd_evening': 0.35,  // 6 PM – 10 PM
+  'wd_night':   0.05,  // 10 PM – 7 AM
+  // Saturday
+  'sat_day':    0.15,  // 8 AM – 6 PM
+  'sat_other':  0.05,  // outside 8–6
+  // Sunday
+  'sun':        0.05,  // all day
+};
+
+/**
+ * Activity-based scaling caps — when there are very few devices campus-wide,
+ * we trust the raw numbers more and limit how much we scale up.
+ */
+const SCALING_CAPS: { threshold: number; maxScaling: number }[] = [
+  { threshold: 500, maxScaling: Infinity }, // Full scaling
+  { threshold: 200, maxScaling: 10 },
+  { threshold: 50,  maxScaling: 5 },
+  { threshold: 0,   maxScaling: 2 },
+];
+
+/**
+ * Campus closure multiplier — near-zero when campus is officially closed.
+ */
+const CLOSURE_MULTIPLIER = 0.02;
+
+/**
+ * Minimum occupancy floor (fraction of capacity) applied to lots with zero
+ * device events during active campus hours.  Prevents showing 0% for lots
+ * that simply lack app users but are certainly occupied.
+ */
+const MIN_FLOOR_RATE = 0.15;
+
+/**
+ * Time-of-day multiplier threshold below which the floor is not applied.
+ * Matches wd_night / sun / sat_other — when the campus is genuinely quiet.
+ */
+const FLOOR_TIME_THRESHOLD = 0.10;
+
+// ─── Service ───────────────────────────────────────────────
+
+/**
+ * Estimates the penetration rate (fraction of commuters using the app) and
+ * scales raw occupancy counts up to approximate true lot occupancy.
+ *
+ * Three-layer approach:
+ *  1. Academic calendar — base expected commuters for the current period
+ *  2. Time-of-day + campus closures — adjust commuters for current conditions
+ *  3. Activity-based cap — prevent over-scaling when campus is quiet
+ */
+@Injectable()
+export class PenetrationEstimationService {
+  private readonly logger = new Logger(PenetrationEstimationService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Estimates occupancy for a single lot.
+   * @param lot  The Prisma Lot row (must include current_occupancy, capacity, penetration_rate)
+   * @param now  Optional override for current time (useful for testing)
+   */
+  async estimateForLot(lot: Lot, now: Date = new Date()): Promise<PenetrationEstimate> {
+    const rawOccupancy = lot.current_occupancy;
+
+    // Layer 1: Academic calendar — base expected commuters
+    const baseCommuters = await this.getExpectedCommuters(lot.school_id, now);
+
+    // Layer 2: Time-of-day + campus closure adjustments
+    const schoolTz = await this.getSchoolTimezone(lot.school_id);
+    const schoolTime = this.toSchoolTime(now, schoolTz);
+    const isClosure = await this.isCampusClosure(lot.school_id, now);
+    const timeMultiplier = isClosure ? CLOSURE_MULTIPLIER : this.getTimeMultiplier(schoolTime);
+    const adjustedCommuters = Math.max(1, Math.round(baseCommuters * timeMultiplier));
+
+    // Count campus-wide active devices
+    const campusDevices = await this.countCampusDevices(lot.school_id, now);
+
+    // ── Empty-lot floor ──────────────────────────────────────
+    // During active campus hours, lots with 0 device events still get a
+    // minimum estimate proportional to their capacity — students park there
+    // even if none use the app.
+    if (rawOccupancy <= 0) {
+      const floor = this.computeFloor(lot.capacity, timeMultiplier, isClosure);
+      return {
+        effectiveRate: 1,
+        rawOccupancy: 0,
+        estimatedOccupancy: floor,
+        estimatedRate: lot.capacity > 0 ? Math.round((floor / lot.capacity) * 1000) / 1000 : 0,
+        campusDevices,
+        adjustedCommuters,
+        isClosure,
+      };
+    }
+
+    // Compute penetration rate
+    const campusRate = campusDevices > 0 ? campusDevices / adjustedCommuters : 0;
+
+    // Use the most conservative (highest) rate → lowest estimate
+    const effectiveRate = Math.max(campusRate, lot.penetration_rate, MIN_PENETRATION_RATE);
+
+    // Determine scaling cap based on campus activity
+    const maxScaling = this.getMaxScaling(campusDevices);
+
+    // Apply scaling with cap
+    const rawScaling = 1 / effectiveRate;
+    const cappedScaling = Math.min(rawScaling, maxScaling);
+    const scaledOccupancy = Math.round(rawOccupancy * cappedScaling);
+
+    // Clamp: never below raw, never above capacity
+    const estimatedOccupancy = Math.max(rawOccupancy, Math.min(scaledOccupancy, lot.capacity));
+    const estimatedRate = lot.capacity > 0 ? estimatedOccupancy / lot.capacity : 0;
+
+    return {
+      effectiveRate: Math.round(effectiveRate * 10000) / 10000,
+      rawOccupancy,
+      estimatedOccupancy,
+      estimatedRate: Math.round(estimatedRate * 1000) / 1000,
+      campusDevices,
+      adjustedCommuters,
+      isClosure,
+    };
+  }
+
+  /**
+   * Batch estimation for all lots (used by snapshot job and findAll).
+   * Queries campus-wide data once and reuses it.
+   */
+  async estimateForAllLots(lots: Lot[], now: Date = new Date()): Promise<Map<string, PenetrationEstimate>> {
+    const results = new Map<string, PenetrationEstimate>();
+
+    if (lots.length === 0) return results;
+
+    // All lots belong to the same school in our current setup
+    const schoolId = lots[0].school_id;
+
+    // Shared queries (run once for the batch)
+    const [baseCommuters, isClosure, campusDevices, schoolTz] = await Promise.all([
+      this.getExpectedCommuters(schoolId, now),
+      this.isCampusClosure(schoolId, now),
+      this.countCampusDevices(schoolId, now),
+      this.getSchoolTimezone(schoolId),
+    ]);
+
+    const schoolTime = this.toSchoolTime(now, schoolTz);
+    const timeMultiplier = isClosure ? CLOSURE_MULTIPLIER : this.getTimeMultiplier(schoolTime);
+    const adjustedCommuters = Math.max(1, Math.round(baseCommuters * timeMultiplier));
+    const campusRate = campusDevices > 0 ? campusDevices / adjustedCommuters : 0;
+    const maxScaling = this.getMaxScaling(campusDevices);
+
+    for (const lot of lots) {
+      if (lot.current_occupancy <= 0) {
+        const floor = this.computeFloor(lot.capacity, timeMultiplier, isClosure);
+        results.set(lot.id, {
+          effectiveRate: 1,
+          rawOccupancy: 0,
+          estimatedOccupancy: floor,
+          estimatedRate: lot.capacity > 0 ? Math.round((floor / lot.capacity) * 1000) / 1000 : 0,
+          campusDevices,
+          adjustedCommuters,
+          isClosure,
+        });
+        continue;
+      }
+
+      const effectiveRate = Math.max(campusRate, lot.penetration_rate, MIN_PENETRATION_RATE);
+      const rawScaling = 1 / effectiveRate;
+      const cappedScaling = Math.min(rawScaling, maxScaling);
+      const scaledOccupancy = Math.round(lot.current_occupancy * cappedScaling);
+      const estimatedOccupancy = Math.max(lot.current_occupancy, Math.min(scaledOccupancy, lot.capacity));
+      const estimatedRate = lot.capacity > 0 ? estimatedOccupancy / lot.capacity : 0;
+
+      results.set(lot.id, {
+        effectiveRate: Math.round(effectiveRate * 10000) / 10000,
+        rawOccupancy: lot.current_occupancy,
+        estimatedOccupancy,
+        estimatedRate: Math.round(estimatedRate * 1000) / 1000,
+        campusDevices,
+        adjustedCommuters,
+        isClosure,
+      });
+    }
+
+    return results;
+  }
+
+  // ─── Empty-Lot Floor ─────────────────────────────────────
+
+  /**
+   * Computes a minimum occupancy estimate for lots with zero device events.
+   * Applied only during active campus hours (time multiplier above threshold
+   * and campus is not on a closure day).
+   *
+   * Formula: floor(capacity × MIN_FLOOR_RATE × timeMultiplier)
+   * → e.g. 1,000-space lot at weekday peak: 1000 × 0.15 × 1.0 = 150
+   * → same lot Saturday afternoon: 1000 × 0.15 × 0.15 = 22
+   */
+  computeFloor(capacity: number, timeMultiplier: number, isClosure: boolean): number {
+    if (isClosure || timeMultiplier < FLOOR_TIME_THRESHOLD) return 0;
+    return Math.floor(capacity * MIN_FLOOR_RATE * timeMultiplier);
+  }
+
+  // ─── Layer 1: Academic Calendar ──────────────────────────
+
+  /**
+   * Returns the expected_commuters for the academic period containing `date`.
+   * Falls back to DEFAULT_COMMUTERS if no matching period exists.
+   */
+  async getExpectedCommuters(schoolId: string, date: Date): Promise<number> {
+    const period = await this.prisma.academicCalendar.findFirst({
+      where: {
+        school_id: schoolId,
+        start_date: { lte: date },
+        end_date: { gte: date },
+      },
+      orderBy: { start_date: 'desc' },
+    });
+
+    if (period) {
+      return period.expected_commuters;
+    }
+
+    // No matching period — try the most recent one as fallback
+    const recent = await this.prisma.academicCalendar.findFirst({
+      where: { school_id: schoolId, end_date: { lt: date } },
+      orderBy: { end_date: 'desc' },
+    });
+
+    if (recent) {
+      this.logger.warn(
+        `No academic period for ${date.toISOString()}. Using most recent: ${recent.period_name} (${recent.expected_commuters} commuters)`,
+      );
+      return recent.expected_commuters;
+    }
+
+    this.logger.warn(`No academic calendar data found. Using default: ${DEFAULT_COMMUTERS}`);
+    return DEFAULT_COMMUTERS;
+  }
+
+  // ─── Layer 2: Time & Closures ────────────────────────────
+
+  /**
+   * Returns the IANA timezone string for a school (e.g. "America/Los_Angeles").
+   * Falls back to America/Los_Angeles if not found.
+   */
+  async getSchoolTimezone(schoolId: string): Promise<string> {
+    const school = await this.prisma.school.findUnique({
+      where: { id: schoolId },
+      select: { timezone: true },
+    });
+    return school?.timezone ?? 'America/Los_Angeles';
+  }
+
+  /**
+   * Converts a UTC Date to a Date whose getDay()/getHours() return values
+   * in the school's local timezone.
+   */
+  toSchoolTime(date: Date, timezone: string): Date {
+    const localeStr = date.toLocaleString('en-US', { timeZone: timezone });
+    return new Date(localeStr);
+  }
+
+  /**
+   * Returns a multiplier (0–1) for the given time based on day-of-week and hour.
+   * Expects a Date already converted to the school's local timezone.
+   */
+  getTimeMultiplier(date: Date): number {
+    const day = date.getDay(); // 0 = Sunday
+    const hour = date.getHours();
+
+    if (day === 0) return TIME_MULTIPLIERS['sun'];
+
+    if (day === 6) {
+      // Saturday
+      return (hour >= 8 && hour < 18)
+        ? TIME_MULTIPLIERS['sat_day']
+        : TIME_MULTIPLIERS['sat_other'];
+    }
+
+    // Weekday (Mon–Fri)
+    if (hour >= 7 && hour < 18) return TIME_MULTIPLIERS['wd_peak'];
+    if (hour >= 18 && hour < 22) return TIME_MULTIPLIERS['wd_evening'];
+    return TIME_MULTIPLIERS['wd_night'];
+  }
+
+  /**
+   * Checks whether the given date falls on a campus closure.
+   */
+  async isCampusClosure(schoolId: string, date: Date): Promise<boolean> {
+    // Normalize to date-only (midnight UTC)
+    const startOfDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000 - 1);
+
+    const closure = await this.prisma.campusClosure.findFirst({
+      where: {
+        school_id: schoolId,
+        date: { gte: startOfDay, lte: endOfDay },
+      },
+    });
+
+    return closure !== null;
+  }
+
+  // ─── Layer 3: Activity-Based Cap ─────────────────────────
+
+  /**
+   * Counts unique active devices campus-wide in the observation window.
+   * Uses raw SQL COUNT(DISTINCT) to avoid loading event rows into memory.
+   */
+  async countCampusDevices(schoolId: string, now: Date): Promise<number> {
+    const windowStart = new Date(now.getTime() - DEVICE_WINDOW_MS);
+
+    const result = await this.prisma.$queryRaw<[{ count: bigint }]>(
+      Prisma.sql`
+        SELECT COUNT(DISTINCT oe.device_hash) AS count
+        FROM occupancy_events oe
+        JOIN lots l ON l.id = oe.lot_id
+        WHERE l.school_id = ${schoolId}
+          AND oe.timestamp >= ${windowStart}
+          AND oe.timestamp <= ${now}
+      `,
+    );
+
+    return Number(result[0]?.count ?? 0);
+  }
+
+  /**
+   * Returns the maximum scaling factor based on campus-wide device activity.
+   * Fewer devices → lower cap → trust raw numbers more.
+   */
+  getMaxScaling(campusDevices: number): number {
+    for (const cap of SCALING_CAPS) {
+      if (campusDevices >= cap.threshold) {
+        return cap.maxScaling;
+      }
+    }
+    return 2; // fallback
+  }
+}

--- a/apps/backend/src/occupancy-events/occupancy-events.module.ts
+++ b/apps/backend/src/occupancy-events/occupancy-events.module.ts
@@ -1,6 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ReliabilityModule } from '../reliability/reliability.module';
+import { LotsModule } from '../lots/lots.module';
 import { AuthModule } from '../auth/auth.module';
 import { OccupancyEventsController } from './occupancy-events.controller';
 import { OccupancyEventsService } from './occupancy-events.service';
@@ -11,6 +12,7 @@ import { OccupancyEventsScheduler } from './occupancy-events.scheduler';
   imports: [
     ScheduleModule.forRoot(),
     forwardRef(() => ReliabilityModule),
+    LotsModule,
     AuthModule,
   ],
   controllers: [OccupancyEventsController],

--- a/apps/backend/src/occupancy-events/occupancy-events.service.spec.ts
+++ b/apps/backend/src/occupancy-events/occupancy-events.service.spec.ts
@@ -183,6 +183,42 @@ describe('OccupancyEventsService', () => {
 
       await expect(service.create(validDto)).rejects.toThrow('Failed to record occupancy event');
     });
+
+    it('should throw NotFoundException when lot not found', async () => {
+      prisma.lot.findFirst.mockResolvedValue(null);
+
+      await expect(service.create(validDto)).rejects.toThrow('Lot G1 not found');
+    });
+
+    it('should not decrement occupancy below 0 on EXIT', async () => {
+      const zeroLot = { ...mockLot, current_occupancy: 0 };
+      const exitDto = { ...validDto, event_type: 'EXIT' as const };
+
+      prisma.lot.findFirst.mockResolvedValue(zeroLot);
+      prisma.deviceState.findUnique.mockResolvedValue(null);
+      prisma.$transaction.mockImplementation(async (fn: (tx: typeof prisma) => Promise<void>) => {
+        await fn(prisma);
+      });
+
+      const result = await service.create(exitDto);
+
+      expect(result.deduplicated).toBe(false);
+      // lot.update should NOT be called because occupancy is already 0
+      expect(prisma.lot.update).not.toHaveBeenCalled();
+    });
+
+    it('should handle checkDuplicate failure gracefully (not duplicate)', async () => {
+      prisma.lot.findFirst.mockResolvedValue(mockLot);
+      prisma.deviceState.findUnique.mockRejectedValue(new Error('Redis down'));
+      prisma.$transaction.mockImplementation(async (fn: (tx: typeof prisma) => Promise<void>) => {
+        await fn(prisma);
+      });
+
+      const result = await service.create(validDto);
+
+      // Should proceed as non-duplicate when checkDuplicate fails
+      expect(result.deduplicated).toBe(false);
+    });
   });
 
   describe('findByLot', () => {

--- a/apps/backend/src/occupancy-events/occupancy-events.service.spec.ts
+++ b/apps/backend/src/occupancy-events/occupancy-events.service.spec.ts
@@ -3,6 +3,7 @@ import { OccupancyEventsService } from './occupancy-events.service';
 import { PrismaService } from '../database/database.module';
 import { ReliabilityService } from '../reliability/reliability.service';
 import { ReliabilityComputationService } from '../reliability/reliability-computation.service';
+import { PenetrationEstimationService } from '../lots/penetration-estimation.service';
 
 describe('OccupancyEventsService', () => {
   let service: OccupancyEventsService;
@@ -19,6 +20,11 @@ describe('OccupancyEventsService', () => {
   let mockReliabilityComputationService: {
     computeReliability: jest.Mock;
     gatherReliabilityInput: jest.Mock;
+  };
+  let mockPenetrationService: {
+    estimateForAllLots: jest.Mock;
+    estimateForLot: jest.Mock;
+    isCampusClosure: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -51,12 +57,33 @@ describe('OccupancyEventsService', () => {
       }),
     };
 
+    mockPenetrationService = {
+      estimateForAllLots: jest.fn().mockImplementation(async (lots: any[]) => {
+        const map = new Map();
+        for (const lot of lots) {
+          map.set(lot.id, {
+            effectiveRate: 1,
+            rawOccupancy: lot.current_occupancy || 0,
+            estimatedOccupancy: lot.current_occupancy || 0,
+            estimatedRate: lot.capacity > 0 ? (lot.current_occupancy || 0) / lot.capacity : 0,
+            campusDevices: 0,
+            adjustedCommuters: 0,
+            isClosure: false,
+          });
+        }
+        return map;
+      }),
+      estimateForLot: jest.fn(),
+      isCampusClosure: jest.fn().mockResolvedValue(false),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         OccupancyEventsService,
         { provide: PrismaService, useValue: prisma },
         { provide: ReliabilityService, useValue: mockReliabilityService },
         { provide: ReliabilityComputationService, useValue: mockReliabilityComputationService },
+        { provide: PenetrationEstimationService, useValue: mockPenetrationService },
       ],
     }).compile();
 
@@ -233,10 +260,10 @@ describe('OccupancyEventsService', () => {
   });
 
   describe('createSnapshots', () => {
-    it('should create snapshots for all lots', async () => {
+    it('should create snapshots for all lots with estimated occupancy', async () => {
       const mockLots = [
-        { id: 'lot-uuid-1', lot_id: 'G1', current_occupancy: 50, capacity: 100, penetration_rate: 0.8 },
-        { id: 'lot-uuid-2', lot_id: 'E7', current_occupancy: 30, capacity: 80, penetration_rate: 0.5 },
+        { id: 'lot-uuid-1', lot_id: 'G1', current_occupancy: 50, capacity: 100, penetration_rate: 0.8, school_id: 'school-1' },
+        { id: 'lot-uuid-2', lot_id: 'E7', current_occupancy: 30, capacity: 80, penetration_rate: 0.5, school_id: 'school-1' },
       ];
 
       prisma.lot.findMany.mockResolvedValue(mockLots);
@@ -248,6 +275,15 @@ describe('OccupancyEventsService', () => {
       expect(result.count).toBe(2);
       expect(result.timestamp).toBeDefined();
       expect(prisma.occupancySnapshot.create).toHaveBeenCalledTimes(2);
+      expect(mockPenetrationService.estimateForAllLots).toHaveBeenCalledWith(mockLots, expect.any(Date));
+
+      // Verify snapshot includes estimated_occupancy and penetration_rate_used
+      const firstCallData = prisma.occupancySnapshot.create.mock.calls[0][0].data;
+      expect(firstCallData.estimated_occupancy).toBe(50);
+      expect(firstCallData.penetration_rate_used).toBe(1);
+      expect(firstCallData.occupancy).toBe(50); // raw occupancy preserved
+      expect(firstCallData.available).toBe(50); // raw: capacity(100) - rawOccupancy(50)
+      expect(firstCallData.is_campus_open).toBe(true); // derived from estimate.isClosure
     });
 
     it('should throw InternalServerErrorException on error', async () => {

--- a/apps/backend/src/occupancy-events/occupancy-events.service.spec.ts
+++ b/apps/backend/src/occupancy-events/occupancy-events.service.spec.ts
@@ -25,6 +25,8 @@ describe('OccupancyEventsService', () => {
     estimateForAllLots: jest.Mock;
     estimateForLot: jest.Mock;
     isCampusClosure: jest.Mock;
+    getSchoolTimezone: jest.Mock;
+    toSchoolTime: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -74,7 +76,9 @@ describe('OccupancyEventsService', () => {
         return map;
       }),
       estimateForLot: jest.fn(),
-      isCampusClosure: jest.fn().mockResolvedValue(false),
+      isCampusClosure: jest.fn().mockReturnValue(false),
+      getSchoolTimezone: jest.fn().mockResolvedValue('America/Los_Angeles'),
+      toSchoolTime: jest.fn().mockImplementation((date: Date) => date),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -320,6 +324,11 @@ describe('OccupancyEventsService', () => {
       expect(firstCallData.occupancy).toBe(50); // raw occupancy preserved
       expect(firstCallData.available).toBe(50); // raw: capacity(100) - rawOccupancy(50)
       expect(firstCallData.is_campus_open).toBe(true); // derived from estimate.isClosure
+
+      // Academic calendar ML feature columns
+      expect(firstCallData.semester).toBeDefined();
+      expect(firstCallData.academic_period).toBeDefined();
+      expect(typeof firstCallData.week_of_semester).toBe('number');
     });
 
     it('should throw InternalServerErrorException on error', async () => {

--- a/apps/backend/src/occupancy-events/occupancy-events.service.ts
+++ b/apps/backend/src/occupancy-events/occupancy-events.service.ts
@@ -10,6 +10,7 @@ import type {
 import { hashDeviceId, generateEventId } from './utils/privacy.util';
 import { ReliabilityService } from '../reliability/reliability.service';
 import { ReliabilityComputationService } from '../reliability/reliability-computation.service';
+import { PenetrationEstimationService } from '../lots/penetration-estimation.service';
 
 /** Service for anonymous occupancy events - handles storage, deduplication, and real-time updates */
 @Injectable()
@@ -20,6 +21,7 @@ export class OccupancyEventsService {
     private readonly prisma: PrismaService,
     @Inject(forwardRef(() => ReliabilityService)) private readonly reliabilityService: ReliabilityService,
     @Inject(forwardRef(() => ReliabilityComputationService)) private readonly reliabilityComputationService: ReliabilityComputationService,
+    private readonly penetrationService: PenetrationEstimationService,
   ) {}
 
   /**
@@ -162,12 +164,20 @@ export class OccupancyEventsService {
     try {
       const lots = await this.prisma.lot.findMany();
 
+      // Batch-estimate penetration for all lots at once
+      const estimates = await this.penetrationService.estimateForAllLots(lots, now);
+
       let count = 0;
       for (const lot of lots) {
-        const occupancy = lot.current_occupancy || 0;
+        const estimate = estimates.get(lot.id);
+        const rawOccupancy = lot.current_occupancy || 0;
+        const estimatedOccupancy = estimate ? estimate.estimatedOccupancy : rawOccupancy;
         const capacity = lot.capacity || 100;
-        const available = Math.max(0, capacity - occupancy);
-        const occupancyRate = capacity > 0 ? occupancy / capacity : 0;
+
+        // Snapshot stores raw occupancy/available/rate for ML consistency;
+        // estimated_occupancy is the separate scaled-up field
+        const rawAvailable = Math.max(0, capacity - rawOccupancy);
+        const rawOccupancyRate = capacity > 0 ? rawOccupancy / capacity : 0;
 
         // Compute confidence using ReliabilityComputationService (single source of truth)
         const reliabilityInput = await this.reliabilityComputationService.gatherReliabilityInput(lot.lot_id, lot);
@@ -181,13 +191,17 @@ export class OccupancyEventsService {
           data: {
             lot_id: lot.id,
             timestamp: now,
-            occupancy,
-            available,
-            occupancy_rate: Math.round(occupancyRate * 1000) / 1000,
+            occupancy: rawOccupancy,
+            available: rawAvailable,
+            occupancy_rate: Math.round(rawOccupancyRate * 1000) / 1000,
             confidence,
             reliability_score: reliabilityScore.score,
             is_cold_start: reliabilityScore.isColdStart,
-            is_campus_open: true, // TODO: derive from academic calendar
+            is_campus_open: estimate ? !estimate.isClosure : true,
+            estimated_occupancy: estimatedOccupancy,
+            penetration_rate_used: estimate
+              ? Math.round(estimate.effectiveRate * 10000) / 10000
+              : null,
           },
         });
 

--- a/apps/backend/src/occupancy-events/occupancy-events.service.ts
+++ b/apps/backend/src/occupancy-events/occupancy-events.service.ts
@@ -11,6 +11,10 @@ import { hashDeviceId, generateEventId } from './utils/privacy.util';
 import { ReliabilityService } from '../reliability/reliability.service';
 import { ReliabilityComputationService } from '../reliability/reliability-computation.service';
 import { PenetrationEstimationService } from '../lots/penetration-estimation.service';
+import {
+  getSemester,
+  getWeekOfSemester,
+} from '../lots/academic-calendar';
 
 /** Service for anonymous occupancy events - handles storage, deduplication, and real-time updates */
 @Injectable()
@@ -167,6 +171,18 @@ export class OccupancyEventsService {
       // Batch-estimate penetration for all lots at once
       const estimates = await this.penetrationService.estimateForAllLots(lots, now);
 
+      // Compute academic calendar features once for the batch.
+      // Convert to school local time so calendar lookups are date-correct.
+      const schoolId = lots[0]?.school_id;
+      const schoolTz = schoolId
+        ? await this.penetrationService.getSchoolTimezone(schoolId)
+        : 'America/Los_Angeles';
+      const schoolTime = this.penetrationService.toSchoolTime(now, schoolTz);
+
+      const semester = getSemester(schoolTime);
+      const [weekOfSemester, periodType] = getWeekOfSemester(schoolTime);
+      const academicPeriod = periodType;
+
       let count = 0;
       for (const lot of lots) {
         const estimate = estimates.get(lot.id);
@@ -197,6 +213,9 @@ export class OccupancyEventsService {
             confidence,
             reliability_score: reliabilityScore.score,
             is_cold_start: reliabilityScore.isColdStart,
+            semester,
+            academic_period: academicPeriod,
+            week_of_semester: weekOfSemester,
             is_campus_open: estimate ? !estimate.isClosure : true,
             estimated_occupancy: estimatedOccupancy,
             penetration_rate_used: estimate

--- a/apps/mobile/__tests__/GeofencingIntegration.test.tsx
+++ b/apps/mobile/__tests__/GeofencingIntegration.test.tsx
@@ -1,0 +1,418 @@
+/**
+ * GeofencingIntegration Component Tests
+ *
+ * Tests:
+ *   - Loading state
+ *   - Error state
+ *   - Main render (status, privacy info, stats, enable button)
+ *   - Geofence initialisation when lots arrive
+ *   - Geofence ENTER / EXIT events (Alerts, occupancy, parent callback)
+ *   - Start geofencing flow (permissions + tracking)
+ *   - Permission denied / tracking failed paths
+ *   - Last‑error display
+ */
+import React from 'react';
+import ReactTestRenderer, { act } from 'react-test-renderer';
+import { Alert } from 'react-native';
+
+// ────────────────────── Mocks ──────────────────────
+
+// Provide a minimal implementation of useAllLotsData
+const mockUseAllLotsData = jest.fn();
+jest.mock('../src/hooks/useAllLotsData', () => ({
+  useAllLotsData: () => mockUseAllLotsData(),
+}));
+
+// Provide a controllable mock of useLocationService
+const mockAddGeofenceRegions = jest.fn();
+const mockRequestPermissions = jest.fn();
+const mockStartTracking = jest.fn();
+const defaultLocationState = {
+  isTracking: false,
+  permissionStatus: null as { granted: boolean } | null,
+  monitoredRegions: 0,
+  requestPermissions: mockRequestPermissions,
+  startTracking: mockStartTracking,
+  addGeofenceRegions: mockAddGeofenceRegions,
+  lastGeofenceEvent: null as { eventType: 'ENTER' | 'EXIT'; regionId: string } | null,
+  lastError: null as { message: string } | null,
+};
+let mockLocationState = { ...defaultLocationState };
+jest.mock('../src/hooks/useLocationService', () => ({
+  __esModule: true,
+  default: () => mockLocationState,
+}));
+
+// geofenceUtils
+const mockCreateGeofenceRegionsFromLots = jest.fn().mockReturnValue([]);
+const mockPrioritizeGeofenceRegions = jest.fn().mockReturnValue([]);
+jest.mock('../src/utils/geofenceUtils', () => ({
+  createGeofenceRegionsFromLots: (...a: unknown[]) => mockCreateGeofenceRegionsFromLots(...a),
+  prioritizeGeofenceRegions: (...a: unknown[]) => mockPrioritizeGeofenceRegions(...a),
+}));
+
+// lotsApi
+const mockRecordOccupancyEvent = jest.fn();
+jest.mock('../src/services/api', () => ({
+  lotsApi: {
+    recordOccupancyEvent: (...a: unknown[]) => mockRecordOccupancyEvent(...a),
+  },
+}));
+
+// GeofencingTestUtils – render nothing
+jest.mock('../src/components/GeofencingTestUtils', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="test-utils" /> };
+});
+
+// Alert spy
+jest.spyOn(Alert, 'alert');
+
+import { GeofencingIntegration } from '../src/components/GeofencingIntegration';
+
+// ────────────────────── Helpers ──────────────────────
+
+const makeLot = (overrides: Record<string, unknown> = {}) => ({
+  lot_id: 'G1',
+  lot_name: 'Lot G1',
+  display_name: 'Lot G1 – Science',
+  capacity: 200,
+  current_occupancy: 100,
+  occupancy_rate: 0.5,
+  available: 100,
+  estimated_available: 95,
+  ...overrides,
+});
+
+function renderComponent(props: { onGeofenceEvent?: (e: { lotId: string; eventType: 'ENTER' | 'EXIT' }) => void } = {}) {
+  let root: ReactTestRenderer.ReactTestRenderer;
+  act(() => {
+    root = ReactTestRenderer.create(<GeofencingIntegration {...props} />);
+  });
+  return root!;
+}
+
+// ────────────────────── Tests ──────────────────────
+
+describe('GeofencingIntegration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLocationState = { ...defaultLocationState };
+    mockRequestPermissions.mockResolvedValue(true);
+    mockStartTracking.mockResolvedValue(true);
+    mockRecordOccupancyEvent.mockResolvedValue({ event_id: 'e1', deduplicated: false });
+  });
+
+  // ── Loading & Error ────────────────────────────────
+
+  it('renders loading state', () => {
+    mockUseAllLotsData.mockReturnValue({ lots: [], loading: true, error: null });
+    const root = renderComponent();
+    const json = root.toJSON() as ReactTestRenderer.ReactTestRendererJSON;
+
+    // Look for "Loading parking lot data..."
+    const textNodes = JSON.stringify(json);
+    expect(textNodes).toContain('Loading parking lot data...');
+  });
+
+  it('renders error state', () => {
+    mockUseAllLotsData.mockReturnValue({ lots: [], loading: false, error: 'Network fail' });
+    const root = renderComponent();
+    const text = JSON.stringify(root.toJSON());
+    expect(text).toContain('Error loading parking lots');
+    expect(text).toContain('Network fail');
+  });
+
+  // ── Normal render ──────────────────────────────────
+
+  it('renders title, status, privacy info and stats', () => {
+    mockUseAllLotsData.mockReturnValue({ lots: [makeLot()], loading: false, error: null });
+    const root = renderComponent();
+    const text = JSON.stringify(root.toJSON());
+
+    expect(text).toContain('Smart Parking Detection');
+    expect(text).toContain('Inactive');
+    expect(text).toContain('Privacy-First Tracking');
+    expect(text).toContain('0 of 1'); // monitored 0 of 1
+  });
+
+  it('shows "Active" when isTracking is true', () => {
+    mockUseAllLotsData.mockReturnValue({ lots: [makeLot()], loading: false, error: null });
+    mockLocationState = { ...defaultLocationState, isTracking: true };
+    const root = renderComponent();
+    const text = JSON.stringify(root.toJSON());
+    expect(text).toContain('Active');
+  });
+
+  it('shows enable button when not tracking', () => {
+    mockUseAllLotsData.mockReturnValue({ lots: [makeLot()], loading: false, error: null });
+    const root = renderComponent();
+    const text = JSON.stringify(root.toJSON());
+    expect(text).toContain('Enable Smart Parking Detection');
+  });
+
+  it('hides enable button when tracking', () => {
+    mockUseAllLotsData.mockReturnValue({ lots: [makeLot()], loading: false, error: null });
+    mockLocationState = { ...defaultLocationState, isTracking: true };
+    const root = renderComponent();
+    const text = JSON.stringify(root.toJSON());
+    expect(text).not.toContain('Enable Smart Parking Detection');
+  });
+
+  it('displays lastError when present', () => {
+    mockUseAllLotsData.mockReturnValue({ lots: [makeLot()], loading: false, error: null });
+    mockLocationState = { ...defaultLocationState, lastError: { message: 'GPS failure' } };
+    const root = renderComponent();
+    const text = JSON.stringify(root.toJSON());
+    expect(text).toContain('GPS failure');
+  });
+
+  it('displays permission status as Granted', () => {
+    mockUseAllLotsData.mockReturnValue({ lots: [makeLot()], loading: false, error: null });
+    mockLocationState = { ...defaultLocationState, permissionStatus: { granted: true } };
+    const root = renderComponent();
+    const text = JSON.stringify(root.toJSON());
+    expect(text).toContain('Granted');
+  });
+
+  // ── Geofence initialisation ────────────────────────
+
+  it('initializes geofencing when lots are available', () => {
+    const lots = [makeLot()];
+    const regions = [{ id: 'G1', latitude: 33, longitude: -118, radius: 50 }];
+    mockCreateGeofenceRegionsFromLots.mockReturnValue(regions);
+    mockPrioritizeGeofenceRegions.mockReturnValue(regions);
+    mockUseAllLotsData.mockReturnValue({ lots, loading: false, error: null });
+
+    renderComponent();
+
+    expect(mockCreateGeofenceRegionsFromLots).toHaveBeenCalledWith(lots);
+    expect(mockPrioritizeGeofenceRegions).toHaveBeenCalledWith(regions, 20); // MAX_REGIONS_IOS
+    expect(mockAddGeofenceRegions).toHaveBeenCalledWith(regions);
+  });
+
+  // ── Geofence events ────────────────────────────────
+
+  it('shows alert and sends occupancy event on ENTER', async () => {
+    const lots = [makeLot({ lot_id: 'G1', display_name: 'Lot G1 – Science' })];
+    const onEvent = jest.fn();
+
+    // First render – lots loaded, no event yet
+    mockLocationState = { ...defaultLocationState };
+    mockUseAllLotsData.mockReturnValue({ lots, loading: false, error: null });
+    const root = renderComponent({ onGeofenceEvent: onEvent });
+
+    // Second render – fire ENTER event
+    mockLocationState = {
+      ...defaultLocationState,
+      lastGeofenceEvent: { eventType: 'ENTER', regionId: 'G1' },
+    };
+    mockUseAllLotsData.mockReturnValue({ lots, loading: false, error: null });
+
+    await act(async () => {
+      root.update(<GeofencingIntegration onGeofenceEvent={onEvent} />);
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Entered Parking Lot',
+      expect.stringContaining('Lot G1'),
+      expect.any(Array),
+    );
+    expect(mockRecordOccupancyEvent).toHaveBeenCalledWith({
+      lotId: 'G1',
+      eventType: 'ENTER',
+      source: 'GEOFENCE',
+    });
+    expect(onEvent).toHaveBeenCalledWith({ lotId: 'G1', eventType: 'ENTER' });
+  });
+
+  it('shows alert and sends occupancy event on EXIT', async () => {
+    const lots = [makeLot({ lot_id: 'G1' })];
+    const onEvent = jest.fn();
+
+    mockLocationState = { ...defaultLocationState };
+    mockUseAllLotsData.mockReturnValue({ lots, loading: false, error: null });
+    const root = renderComponent({ onGeofenceEvent: onEvent });
+
+    mockLocationState = {
+      ...defaultLocationState,
+      lastGeofenceEvent: { eventType: 'EXIT', regionId: 'G1' },
+    };
+    mockUseAllLotsData.mockReturnValue({ lots, loading: false, error: null });
+
+    await act(async () => {
+      root.update(<GeofencingIntegration onGeofenceEvent={onEvent} />);
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Left Parking Lot',
+      expect.stringContaining('Lot G1'),
+      expect.any(Array),
+    );
+    expect(mockRecordOccupancyEvent).toHaveBeenCalledWith({
+      lotId: 'G1',
+      eventType: 'EXIT',
+      source: 'GEOFENCE',
+    });
+    expect(onEvent).toHaveBeenCalledWith({ lotId: 'G1', eventType: 'EXIT' });
+  });
+
+  it('uses regionId when lot is not found', async () => {
+    // lots list doesn't contain the event regionId
+    mockUseAllLotsData.mockReturnValue({ lots: [], loading: false, error: null });
+    mockLocationState = {
+      ...defaultLocationState,
+      lastGeofenceEvent: { eventType: 'ENTER', regionId: 'UNKNOWN' },
+    };
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Entered Parking Lot',
+      expect.stringContaining('UNKNOWN'),
+      expect.any(Array),
+    );
+  });
+
+  // ── startGeofencing ────────────────────────────────
+
+  it('starts geofencing when button pressed and permissions granted', async () => {
+    mockUseAllLotsData.mockReturnValue({ lots: [makeLot()], loading: false, error: null });
+    const root = renderComponent();
+
+    // Find Button by title
+    const button = root.root.findByProps({ title: 'Enable Smart Parking Detection' });
+    await act(async () => {
+      button.props.onPress();
+    });
+
+    expect(mockRequestPermissions).toHaveBeenCalled();
+    expect(mockStartTracking).toHaveBeenCalled();
+  });
+
+  it('shows alert when permissions denied', async () => {
+    mockRequestPermissions.mockResolvedValue(false);
+    mockUseAllLotsData.mockReturnValue({ lots: [makeLot()], loading: false, error: null });
+    const root = renderComponent();
+
+    const button = root.root.findByProps({ title: 'Enable Smart Parking Detection' });
+    await act(async () => {
+      button.props.onPress();
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Permissions Required',
+      expect.any(String),
+      expect.any(Array),
+    );
+    expect(mockStartTracking).not.toHaveBeenCalled();
+  });
+
+  it('shows alert when tracking fails to start', async () => {
+    mockStartTracking.mockResolvedValue(false);
+    mockUseAllLotsData.mockReturnValue({ lots: [makeLot()], loading: false, error: null });
+    const root = renderComponent();
+
+    const button = root.root.findByProps({ title: 'Enable Smart Parking Detection' });
+    await act(async () => {
+      button.props.onPress();
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Error',
+      expect.any(String),
+      expect.any(Array),
+    );
+  });
+
+  // ── Current lot info card ──────────────────────────
+
+  it('shows current lot info after ENTER event', async () => {
+    const lots = [makeLot({ lot_id: 'G1', display_name: 'Science Lot', capacity: 200, estimated_available: 95, occupancy_rate: 0.5 })];
+    mockUseAllLotsData.mockReturnValue({ lots, loading: false, error: null });
+
+    mockLocationState = {
+      ...defaultLocationState,
+      lastGeofenceEvent: { eventType: 'ENTER', regionId: 'G1' },
+    };
+
+    let root!: ReactTestRenderer.ReactTestRenderer;
+    await act(async () => {
+      root = ReactTestRenderer.create(<GeofencingIntegration />);
+    });
+
+    const text = JSON.stringify(root.toJSON());
+    expect(text).toContain('Currently in');
+    expect(text).toContain('Science Lot');
+    expect(text).toContain('% full');
+  });
+
+  it('clears current lot info after EXIT event', async () => {
+    const lots = [makeLot({ lot_id: 'G1' })];
+    mockUseAllLotsData.mockReturnValue({ lots, loading: false, error: null });
+
+    // First → ENTER
+    mockLocationState = {
+      ...defaultLocationState,
+      lastGeofenceEvent: { eventType: 'ENTER', regionId: 'G1' },
+    };
+    let root!: ReactTestRenderer.ReactTestRenderer;
+    await act(async () => {
+      root = ReactTestRenderer.create(<GeofencingIntegration />);
+    });
+
+    // Then → EXIT
+    mockLocationState = {
+      ...defaultLocationState,
+      lastGeofenceEvent: { eventType: 'EXIT', regionId: 'G1' },
+    };
+    await act(async () => {
+      root.update(<GeofencingIntegration />);
+    });
+
+    const text = JSON.stringify(root.toJSON());
+    expect(text).not.toContain('Currently in');
+  });
+
+  // ── Error resilience ───────────────────────────────
+
+  it('handles occupancy event API failure gracefully', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockRecordOccupancyEvent.mockRejectedValue(new Error('Network gone'));
+    const lots = [makeLot({ lot_id: 'G1' })];
+    mockUseAllLotsData.mockReturnValue({ lots, loading: false, error: null });
+
+    mockLocationState = {
+      ...defaultLocationState,
+      lastGeofenceEvent: { eventType: 'ENTER', regionId: 'G1' },
+    };
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    // Alert still fires even though API failed
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Entered Parking Lot',
+      expect.any(String),
+      expect.any(Array),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('handles geofence initialisation failure gracefully', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockCreateGeofenceRegionsFromLots.mockImplementation(() => { throw new Error('Init fail'); });
+    mockUseAllLotsData.mockReturnValue({ lots: [makeLot()], loading: false, error: null });
+
+    // Should not crash
+    const root = renderComponent();
+    expect(root.toJSON()).toBeTruthy();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/mobile/__tests__/LotAmenities.test.tsx
+++ b/apps/mobile/__tests__/LotAmenities.test.tsx
@@ -1,0 +1,273 @@
+/**
+ * LotAmenities Component Tests
+ *
+ * Tests the lot detail amenities section:
+ *   - Renders all five info cards (Lot Info, Permits, Hours, Spaces, Safety)
+ *   - Conditional rendering (levels for structures, motorcycle when >0, building proximity)
+ *   - EV charging display (none vs count)
+ *   - Hours formatting (object vs "CLOSED" string)
+ *   - Daily permit with/without rate
+ *   - Safety chips (available vs unavailable styling)
+ */
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+// ────────────────────── Mocks ──────────────────────
+
+jest.mock('../src/context/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      primary: '#EBA91B',
+      white: '#ffffff',
+      black: '#1f2937',
+      gray: '#6b7280',
+      lightGray: '#f3f4f6',
+      borderGray: '#e5e7eb',
+      textPrimary: '#111827',
+      shadowDark: '#000',
+    },
+    isDark: false,
+  }),
+}));
+
+import { LotAmenities } from '../src/components/LotAmenities';
+import type { ParkingLotResponse } from '../src/services/api/lots';
+
+// ────────────────────── Helpers ──────────────────────
+
+const makeLot = (overrides: Partial<ParkingLotResponse> = {}): ParkingLotResponse => ({
+  lot_id: 'G1',
+  lot_name: 'Lot G1',
+  display_name: 'Lot G1',
+  lot_number: 'G1',
+  lot_type: 'STUDENT',
+  capacity: 500,
+  current_occupancy: 250,
+  location_description: 'East Campus near ECS Building',
+  building_proximity: ['ECS', 'Library'],
+  center_lat: 33.78,
+  center_lng: -118.11,
+  geofence_polygon: [],
+  geofence_radius: 50,
+  permit_types: ['Gold', 'Green'],
+  daily_permit_allowed: true,
+  daily_rate: 12.5,
+  hours_weekday: { open: '06:00', close: '22:00' },
+  hours_saturday: { open: '08:00', close: '18:00' },
+  hours_sunday: 'CLOSED',
+  ev_charging_stations: 4,
+  motorcycle_spaces: 6,
+  accessible_spaces: 10,
+  has_lighting: true,
+  has_cameras: true,
+  has_emergency_phone: true,
+  is_covered: false,
+  is_paved: true,
+  levels: undefined,
+  penetration_rate: 0.15,
+  avg_turnover_minutes: 120,
+  confidence: 'HIGH',
+  timestamp: new Date().toISOString(),
+  available: 250,
+  occupancy_rate: 0.5,
+  fill_status: 'AVAILABLE',
+  estimated_occupancy: 250,
+  estimated_available: 250,
+  raw_occupancy: 250,
+  effective_penetration_rate: 0.15,
+  ...overrides,
+});
+
+/** Collect all text content from a rendered tree */
+function collectTexts(instance: ReactTestRenderer.ReactTestInstance): string[] {
+  const texts: string[] = [];
+  const walk = (node: ReactTestRenderer.ReactTestInstance) => {
+    if ((node.type as string) === 'Text' && typeof node.children?.[0] === 'string') {
+      texts.push(node.children[0]);
+    }
+    node.children?.forEach(child => {
+      if (typeof child !== 'string') walk(child);
+    });
+  };
+  walk(instance);
+  return texts;
+}
+
+/** Render inside act() — React 19 requires this */
+function renderLot(overrides: Partial<ParkingLotResponse> = {}) {
+  let tree!: ReactTestRenderer.ReactTestRenderer;
+  ReactTestRenderer.act(() => {
+    tree = ReactTestRenderer.create(<LotAmenities lot={makeLot(overrides)} />);
+  });
+  return tree;
+}
+
+// ────────────────────── Tests ──────────────────────
+
+describe('LotAmenities', () => {
+  it('renders all five section titles', () => {
+    const tree = renderLot();
+    const texts = collectTexts(tree.root);
+
+    expect(texts).toContain('Lot Information');
+    expect(texts).toContain('Permits & Rates');
+    expect(texts).toContain('Hours');
+    expect(texts).toContain('Special Spaces');
+    expect(texts).toContain('Safety & Features');
+  });
+
+  it('renders capacity and location description', () => {
+    const tree = renderLot({ capacity: 1234, location_description: 'North Campus' });
+    const texts = collectTexts(tree.root);
+
+    expect(texts).toContain('Capacity');
+    expect(texts.some(t => t.includes('1,234'))).toBe(true);
+    expect(texts).toContain('North Campus');
+  });
+
+  it('renders type as Surface for uncovered lots', () => {
+    const tree = renderLot({ is_covered: false });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('Surface');
+  });
+
+  it('renders type as Structure for covered lots', () => {
+    const tree = renderLot({ is_covered: true });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('Structure');
+  });
+
+  it('renders levels when present and > 0', () => {
+    const tree = renderLot({ is_covered: true, levels: 5 });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('Levels');
+    expect(texts).toContain('5');
+  });
+
+  it('does not render levels when null', () => {
+    const tree = renderLot({ levels: undefined });
+    const texts = collectTexts(tree.root);
+    expect(texts).not.toContain('Levels');
+  });
+
+  it('renders building proximity when non-empty', () => {
+    const tree = renderLot({ building_proximity: ['Library', 'ECS'] });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('Near');
+    expect(texts).toContain('Library, ECS');
+  });
+
+  it('does not render Near when building_proximity is empty', () => {
+    const tree = renderLot({ building_proximity: [] });
+    const texts = collectTexts(tree.root);
+    expect(texts).not.toContain('Near');
+  });
+
+  it('renders permit types', () => {
+    const tree = renderLot({ permit_types: ['Gold', 'Green', 'Purple'] });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('Gold, Green, Purple');
+  });
+
+  it('renders daily rate when daily_permit_allowed with rate', () => {
+    const tree = renderLot({ daily_permit_allowed: true, daily_rate: 12.5 });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('$12.50');
+  });
+
+  it('renders Available when daily_permit_allowed without rate', () => {
+    const tree = renderLot({ daily_permit_allowed: true, daily_rate: undefined });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('Available');
+  });
+
+  it('renders Not Available when daily_permit_allowed is false', () => {
+    const tree = renderLot({ daily_permit_allowed: false });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('Not Available');
+  });
+
+  it('renders weekday hours from object format', () => {
+    const tree = renderLot({ hours_weekday: { open: '06:00', close: '22:00' } });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('06:00 – 22:00');
+  });
+
+  it('renders CLOSED string hours directly', () => {
+    const tree = renderLot({ hours_sunday: 'CLOSED' });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('CLOSED');
+  });
+
+  it('renders EV charging station count when > 0', () => {
+    const tree = renderLot({ ev_charging_stations: 4 });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('4 stations');
+  });
+
+  it('renders singular station when exactly 1', () => {
+    const tree = renderLot({ ev_charging_stations: 1 });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('1 station');
+  });
+
+  it('renders None when EV charging is 0', () => {
+    const tree = renderLot({ ev_charging_stations: 0 });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('None');
+  });
+
+  it('renders accessible spaces', () => {
+    const tree = renderLot({ accessible_spaces: 10 });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('10 spaces');
+  });
+
+  it('renders singular accessible space', () => {
+    const tree = renderLot({ accessible_spaces: 1 });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('1 space');
+  });
+
+  it('renders motorcycle spaces when > 0', () => {
+    const tree = renderLot({ motorcycle_spaces: 6 });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('Motorcycle');
+    expect(texts).toContain('6 spaces');
+  });
+
+  it('does not render motorcycle row when 0', () => {
+    const tree = renderLot({ motorcycle_spaces: 0 });
+    const texts = collectTexts(tree.root);
+    expect(texts).not.toContain('Motorcycle');
+  });
+
+  it('renders all safety chips', () => {
+    const tree = renderLot({
+      has_lighting: true,
+      has_cameras: false,
+      has_emergency_phone: true,
+      is_covered: false,
+      is_paved: true,
+    });
+    const texts = collectTexts(tree.root);
+
+    expect(texts).toContain('Lighting');
+    expect(texts).toContain('Cameras');
+    expect(texts).toContain('Emergency Phone');
+    expect(texts).toContain('Open Air');  // is_covered = false
+    expect(texts).toContain('Paved');     // is_paved = true
+  });
+
+  it('renders Covered chip when is_covered is true', () => {
+    const tree = renderLot({ is_covered: true });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('Covered');
+  });
+
+  it('renders Unpaved chip when is_paved is false', () => {
+    const tree = renderLot({ is_paved: false });
+    const texts = collectTexts(tree.root);
+    expect(texts).toContain('Unpaved');
+  });
+});

--- a/apps/mobile/__tests__/MapScreen.test.tsx
+++ b/apps/mobile/__tests__/MapScreen.test.tsx
@@ -148,6 +148,10 @@ const mockApiLots = [
     occupancy_rate: 0.45,
     available: 110,
     fill_status: 'AVAILABLE',
+    estimated_occupancy: 90,
+    estimated_available: 110,
+    raw_occupancy: 90,
+    effective_penetration_rate: 1,
   },
   {
     lot_id: 'G2',
@@ -157,6 +161,10 @@ const mockApiLots = [
     occupancy_rate: 0.70,
     available: 90,
     fill_status: 'FILLING',
+    estimated_occupancy: 210,
+    estimated_available: 90,
+    raw_occupancy: 210,
+    effective_penetration_rate: 1,
   },
 ];
 

--- a/apps/mobile/__tests__/RecommendationModal.test.tsx
+++ b/apps/mobile/__tests__/RecommendationModal.test.tsx
@@ -72,6 +72,10 @@ const makeLot = (overrides: Partial<ParkingLotResponse> = {}): ParkingLotRespons
   available: 100,
   occupancy_rate: 0.5,
   fill_status: 'AVAILABLE',
+  estimated_occupancy: 100,
+  estimated_available: 100,
+  raw_occupancy: 100,
+  effective_penetration_rate: 1,
   ...overrides,
 });
 
@@ -99,6 +103,10 @@ const lotG2 = makeLot({
   current_occupancy: 120,
   occupancy_rate: 0.4,
   available: 180,
+  estimated_occupancy: 120,
+  estimated_available: 180,
+  raw_occupancy: 120,
+  effective_penetration_rate: 1,
 });
 
 // ────────────────────── Tests ──────────────────────
@@ -471,6 +479,10 @@ describe('RecommendationModal', () => {
         current_occupancy: 80,
         occupancy_rate: 0.8,
         available: 20,
+        estimated_occupancy: 80,
+        estimated_available: 20,
+        raw_occupancy: 80,
+        effective_penetration_rate: 1,
         fill_status: 'NEARLY_FULL',
       });
       mockUseLotsList.mockReturnValue({ lots: [lotG1, highOccupancyLot], loading: false });

--- a/apps/mobile/__tests__/useAllLotsData.test.ts
+++ b/apps/mobile/__tests__/useAllLotsData.test.ts
@@ -1,0 +1,176 @@
+/**
+ * useAllLotsData Hook Tests
+ *
+ * Tests the hook for fetching all lots data:
+ *   - Initial fetch on mount
+ *   - Polling every 30s
+ *   - AppState foreground refresh
+ *   - Error handling
+ *   - Clean-up on unmount
+ */
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { AppState, type AppStateStatus } from 'react-native';
+
+// ────────────────────── Mocks ──────────────────────
+
+const mockGetAllLots = jest.fn();
+
+jest.mock('../src/services/api', () => ({
+  lotsApi: {
+    getAllLots: (...args: unknown[]) => mockGetAllLots(...args),
+  },
+}));
+
+// Capture AppState listener
+let appStateChangeHandler: ((state: AppStateStatus) => void) | null = null;
+const mockRemove = jest.fn();
+
+// Ensure AppState.currentState is defined (React Native default)
+Object.defineProperty(AppState, 'currentState', {
+  get: () => 'active',
+  configurable: true,
+});
+
+jest.spyOn(AppState, 'addEventListener').mockImplementation(
+  (_type, handler) => {
+    appStateChangeHandler = handler;
+    return { remove: mockRemove } as ReturnType<typeof AppState.addEventListener>;
+  },
+);
+
+import { useAllLotsData } from '../src/hooks/useAllLotsData';
+
+// ────────────────────── Helpers ──────────────────────
+
+const mockLots = [
+  { lot_id: 'G1', lot_name: 'Lot G1', capacity: 200, current_occupancy: 100 },
+  { lot_id: 'G2', lot_name: 'Lot G2', capacity: 150, current_occupancy: 50 },
+];
+
+// ────────────────────── Tests ──────────────────────
+
+describe('useAllLotsData', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    appStateChangeHandler = null;
+    mockGetAllLots.mockResolvedValue(mockLots);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('fetches lots on mount and returns data', async () => {
+    const { result } = renderHook(() => useAllLotsData());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.lots).toEqual(mockLots);
+    expect(result.current.error).toBeNull();
+    expect(mockGetAllLots).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets loading true initially', () => {
+    mockGetAllLots.mockReturnValue(new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => useAllLotsData());
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('sets error on fetch failure', async () => {
+    mockGetAllLots.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useAllLotsData());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.lots).toEqual([]);
+  });
+
+  it('polls every 30 seconds', async () => {
+    const { result } = renderHook(() => useAllLotsData());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetAllLots).toHaveBeenCalledTimes(1);
+
+    // Advance by 30s — should trigger another fetch
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(mockGetAllLots).toHaveBeenCalledTimes(2);
+
+    // Another 30s
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(mockGetAllLots).toHaveBeenCalledTimes(3);
+  });
+
+  it('cleans up interval and AppState listener on unmount', async () => {
+    const { result, unmount } = renderHook(() => useAllLotsData());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    unmount();
+
+    // Advancing time should not cause more fetches
+    mockGetAllLots.mockClear();
+    await act(async () => {
+      jest.advanceTimersByTime(60_000);
+    });
+
+    expect(mockGetAllLots).not.toHaveBeenCalled();
+    expect(mockRemove).toHaveBeenCalled();
+  });
+
+  it('re-fetches when app comes to foreground', async () => {
+    const { result } = renderHook(() => useAllLotsData());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetAllLots).toHaveBeenCalledTimes(1);
+
+    // Simulate going to background first (sets the ref to 'background')
+    await act(async () => {
+      appStateChangeHandler?.('background');
+    });
+
+    // Now simulate foreground — ref was 'background', next is 'active' → triggers fetch
+    await act(async () => {
+      appStateChangeHandler?.('active');
+    });
+
+    // Should have fetched again on foreground
+    expect(mockGetAllLots).toHaveBeenCalledTimes(2);
+  });
+
+  it('exposes a refresh function', async () => {
+    const { result } = renderHook(() => useAllLotsData());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    mockGetAllLots.mockResolvedValueOnce([{ lot_id: 'G3' }]);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockGetAllLots).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/mobile/__tests__/useLotData.test.ts
+++ b/apps/mobile/__tests__/useLotData.test.ts
@@ -1,0 +1,331 @@
+/**
+ * useLotData & useLotsList Hook Tests
+ *
+ * Tests:
+ *   - useLotData: fetches lot + forecast, polling at 60s, AppState refresh, error handling
+ *   - useLotsList: fetches lot list, polling at 30s, AppState refresh, error handling
+ */
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { AppState, type AppStateStatus } from 'react-native';
+
+// ────────────────────── Mocks ──────────────────────
+
+const mockGetLotDetails = jest.fn();
+const mockGetLotHistory = jest.fn();
+const mockGenerateForecast = jest.fn();
+const mockGetAllLots = jest.fn();
+
+jest.mock('../src/services/api', () => ({
+  lotsApi: {
+    getLotDetails: (...args: unknown[]) => mockGetLotDetails(...args),
+    getLotHistory: (...args: unknown[]) => mockGetLotHistory(...args),
+    generateForecast: (...args: unknown[]) => mockGenerateForecast(...args),
+    getAllLots: (...args: unknown[]) => mockGetAllLots(...args),
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+// Capture AppState listeners
+const appStateListeners: Array<(state: AppStateStatus) => void> = [];
+const mockRemove = jest.fn();
+
+// Ensure AppState.currentState is defined (React Native default)
+Object.defineProperty(AppState, 'currentState', {
+  get: () => 'active',
+  configurable: true,
+});
+
+jest.spyOn(AppState, 'addEventListener').mockImplementation(
+  (_type, handler) => {
+    appStateListeners.push(handler);
+    return { remove: mockRemove } as ReturnType<typeof AppState.addEventListener>;
+  },
+);
+
+import { useLotData, useLotsList } from '../src/hooks/useLotData';
+
+// ────────────────────── Helpers ──────────────────────
+
+const mockLot = {
+  lot_id: 'G1',
+  lot_name: 'Lot G1',
+  capacity: 200,
+  current_occupancy: 100,
+  occupancy_rate: 0.5,
+};
+
+const mockForecast = [
+  { time: '08:00', occupancy: 50, lowerBound: 40, upperBound: 60, accuracy: 0.8 },
+];
+
+const mockLotList = [
+  { lot_id: 'G1', lot_name: 'Lot G1', capacity: 200, current_occupancy: 100 },
+  { lot_id: 'G2', lot_name: 'Lot G2', capacity: 150, current_occupancy: 50 },
+];
+
+// ────────────────────── useLotData Tests ──────────────────────
+
+describe('useLotData', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    appStateListeners.length = 0;
+    mockGetLotDetails.mockResolvedValue(mockLot);
+    mockGetLotHistory.mockResolvedValue([]);
+    mockGenerateForecast.mockReturnValue(mockForecast);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('fetches lot data and forecast on mount', async () => {
+    const { result } = renderHook(() => useLotData('G1'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.lot).toEqual(mockLot);
+    expect(result.current.forecast).toEqual(mockForecast);
+    expect(result.current.error).toBeNull();
+    expect(mockGetLotDetails).toHaveBeenCalledWith('G1');
+  });
+
+  it('sets loading true initially', () => {
+    mockGetLotDetails.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useLotData('G1'));
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('handles error from API', async () => {
+    mockGetLotDetails.mockRejectedValue(new Error('Server error'));
+
+    const { result } = renderHook(() => useLotData('G1'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Failed to fetch lot data');
+    expect(result.current.lot).toBeNull();
+  });
+
+  it('does nothing when lotId is empty', async () => {
+    const { result } = renderHook(() => useLotData(''));
+
+    // Should not fetch
+    expect(mockGetLotDetails).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('polls every 60 seconds', async () => {
+    const { result } = renderHook(() => useLotData('G1'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetLotDetails).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_000);
+    });
+
+    expect(mockGetLotDetails).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-fetches on foreground', async () => {
+    const { result } = renderHook(() => useLotData('G1'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetLotDetails).toHaveBeenCalledTimes(1);
+
+    // Simulate going to background first
+    await act(async () => {
+      for (const handler of appStateListeners) {
+        handler('background');
+      }
+    });
+
+    // Then simulate foreground — ref was 'background', next is 'active' → triggers fetch
+    await act(async () => {
+      for (const handler of appStateListeners) {
+        handler('active');
+      }
+    });
+
+    // Should have fetched again
+    expect(mockGetLotDetails).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans up on unmount', async () => {
+    const { result, unmount } = renderHook(() => useLotData('G1'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    unmount();
+
+    mockGetLotDetails.mockClear();
+    await act(async () => {
+      jest.advanceTimersByTime(120_000);
+    });
+
+    expect(mockGetLotDetails).not.toHaveBeenCalled();
+  });
+
+  it('refreshHistory fetches history data', async () => {
+    const { result } = renderHook(() => useLotData('G1'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.refreshHistory('2026-03-07');
+    });
+
+    // Initial call + explicit call
+    expect(mockGetLotHistory).toHaveBeenCalledWith('G1', { date: '2026-03-07', limit: 96 });
+  });
+
+  it('refreshHistory does nothing when lotId is empty', async () => {
+    const { result } = renderHook(() => useLotData(''));
+
+    await act(async () => {
+      await result.current.refreshHistory();
+    });
+
+    expect(mockGetLotHistory).not.toHaveBeenCalled();
+  });
+});
+
+// ────────────────────── useLotsList Tests ──────────────────────
+
+describe('useLotsList', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    appStateListeners.length = 0;
+    mockGetAllLots.mockResolvedValue(mockLotList);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('fetches lots on mount', async () => {
+    const { result } = renderHook(() => useLotsList());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.lots).toEqual(mockLotList);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('passes filters to API', async () => {
+    const filters = { type: 'STUDENT' as const, available_only: true };
+    const { result } = renderHook(() => useLotsList(filters));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetAllLots).toHaveBeenCalledWith(filters);
+  });
+
+  it('handles errors', async () => {
+    mockGetAllLots.mockRejectedValue(new Error('Fetch failed'));
+
+    const { result } = renderHook(() => useLotsList());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Failed to fetch lots data');
+    expect(result.current.lots).toEqual([]);
+  });
+
+  it('polls every 30 seconds', async () => {
+    const { result } = renderHook(() => useLotsList());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetAllLots).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(mockGetAllLots).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-fetches on foreground', async () => {
+    const { result } = renderHook(() => useLotsList());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      for (const handler of appStateListeners) {
+        handler('background');
+      }
+    });
+
+    await act(async () => {
+      for (const handler of appStateListeners) {
+        handler('active');
+      }
+    });
+
+    expect(mockGetAllLots).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans up on unmount', async () => {
+    const { result, unmount } = renderHook(() => useLotsList());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    unmount();
+
+    mockGetAllLots.mockClear();
+    await act(async () => {
+      jest.advanceTimersByTime(60_000);
+    });
+
+    expect(mockGetAllLots).not.toHaveBeenCalled();
+  });
+
+  it('exposes refreshLots function', async () => {
+    const { result } = renderHook(() => useLotsList());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.refreshLots();
+    });
+
+    expect(mockGetAllLots).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/mobile/src/components/GeofencingIntegration.tsx
+++ b/apps/mobile/src/components/GeofencingIntegration.tsx
@@ -202,8 +202,8 @@ export const GeofencingIntegration: React.FC<GeofencingIntegrationProps> = ({
           </Text>
           <Text style={styles.currentLotDetails}>
             Capacity: {currentLotInfo.capacity} • 
-            Available: {currentLotInfo.available || 'N/A'} • 
-            {Math.round((currentLotInfo.current_occupancy / currentLotInfo.capacity) * 100)}% full
+            Available: ~{currentLotInfo.estimated_available ?? currentLotInfo.available ?? 'N/A'} • 
+            {Math.round((currentLotInfo.occupancy_rate ?? (currentLotInfo.current_occupancy / currentLotInfo.capacity)) * 100)}% full
           </Text>
         </View>
       )}

--- a/apps/mobile/src/components/LotAmenities.tsx
+++ b/apps/mobile/src/components/LotAmenities.tsx
@@ -1,0 +1,301 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Icon from 'react-native-vector-icons/Ionicons';
+import { TYPOGRAPHY, SPACING } from '../constants/theme';
+import { useTheme } from '../context/ThemeContext';
+import type { ParkingLotResponse } from '../services/api/lots';
+
+interface LotAmenitiesProps {
+  lot: ParkingLotResponse;
+}
+
+/* ─── helpers ─── */
+
+/** Format an hours field into a readable string */
+function formatHours(hours: { open: string; close: string } | string): string {
+  if (typeof hours === 'string') return hours; // e.g. "CLOSED"
+  return `${hours.open} – ${hours.close}`;
+}
+
+/** Single icon + label row used throughout the component */
+function AmenityRow({
+  icon,
+  label,
+  value,
+  color,
+}: {
+  icon: string;
+  label: string;
+  value: string | number;
+  color?: string;
+}) {
+  const { colors } = useTheme();
+  return (
+    <View style={rowStyles.row}>
+      <Icon
+        name={icon}
+        size={18}
+        color={color ?? colors.gray}
+        style={rowStyles.icon}
+      />
+      <Text style={[rowStyles.label, { color: colors.textPrimary }]}>
+        {label}
+      </Text>
+      <Text style={[rowStyles.value, { color: colors.gray }]}>{value}</Text>
+    </View>
+  );
+}
+
+/** Boolean amenity shown as a small badge / chip */
+function AmenityChip({
+  icon,
+  label,
+  available,
+}: {
+  icon: string;
+  label: string;
+  available: boolean;
+}) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={[
+        chipStyles.chip,
+        {
+          backgroundColor: available ? '#ecfdf5' : colors.lightGray,
+          borderColor: available ? '#86efac' : colors.borderGray,
+        },
+      ]}
+    >
+      <Icon
+        name={icon}
+        size={14}
+        color={available ? '#16a34a' : colors.gray}
+      />
+      <Text
+        style={[
+          chipStyles.label,
+          { color: available ? '#15803d' : colors.gray },
+        ]}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+/* ─── main component ─── */
+
+export function LotAmenities({ lot }: LotAmenitiesProps) {
+  const { colors } = useTheme();
+
+  const weekdayHours = formatHours(lot.hours_weekday);
+  const saturdayHours = formatHours(lot.hours_saturday);
+  const sundayHours = formatHours(lot.hours_sunday);
+
+  return (
+    <View style={styles.container}>
+      {/* ── Lot Info ── */}
+      <View style={[styles.card, { backgroundColor: colors.white, shadowColor: colors.shadowDark }]}>
+        <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>
+          Lot Information
+        </Text>
+
+        <AmenityRow
+          icon="car-outline"
+          label="Capacity"
+          value={lot.capacity.toLocaleString()}
+        />
+        <AmenityRow
+          icon="layers-outline"
+          label="Type"
+          value={lot.is_covered ? 'Structure' : 'Surface'}
+        />
+        {lot.levels != null && lot.levels > 0 && (
+          <AmenityRow icon="albums-outline" label="Levels" value={lot.levels} />
+        )}
+        <AmenityRow
+          icon="location-outline"
+          label="Location"
+          value={lot.location_description}
+        />
+        {lot.building_proximity.length > 0 && (
+          <AmenityRow
+            icon="business-outline"
+            label="Near"
+            value={lot.building_proximity.join(', ')}
+          />
+        )}
+      </View>
+
+      {/* ── Permits & Rates ── */}
+      <View style={[styles.card, { backgroundColor: colors.white, shadowColor: colors.shadowDark }]}>
+        <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>
+          Permits & Rates
+        </Text>
+
+        <AmenityRow
+          icon="pricetag-outline"
+          label="Permits"
+          value={lot.permit_types.join(', ')}
+        />
+        <AmenityRow
+          icon="cash-outline"
+          label="Daily Permit"
+          value={
+            lot.daily_permit_allowed
+              ? lot.daily_rate != null
+                ? `$${lot.daily_rate.toFixed(2)}`
+                : 'Available'
+              : 'Not Available'
+          }
+        />
+      </View>
+
+      {/* ── Hours ── */}
+      <View style={[styles.card, { backgroundColor: colors.white, shadowColor: colors.shadowDark }]}>
+        <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>
+          Hours
+        </Text>
+
+        <AmenityRow icon="calendar-outline" label="Weekdays" value={weekdayHours} />
+        <AmenityRow icon="calendar-outline" label="Saturday" value={saturdayHours} />
+        <AmenityRow icon="calendar-outline" label="Sunday" value={sundayHours} />
+      </View>
+
+      {/* ── Spaces ── */}
+      <View style={[styles.card, { backgroundColor: colors.white, shadowColor: colors.shadowDark }]}>
+        <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>
+          Special Spaces
+        </Text>
+
+        <AmenityRow
+          icon="flash-outline"
+          label="EV Charging"
+          value={
+            lot.ev_charging_stations > 0
+              ? `${lot.ev_charging_stations} station${lot.ev_charging_stations !== 1 ? 's' : ''}`
+              : 'None'
+          }
+          color={lot.ev_charging_stations > 0 ? '#16a34a' : undefined}
+        />
+        <AmenityRow
+          icon="accessibility-outline"
+          label="Accessible"
+          value={`${lot.accessible_spaces} space${lot.accessible_spaces !== 1 ? 's' : ''}`}
+        />
+        {lot.motorcycle_spaces > 0 && (
+          <AmenityRow
+            icon="bicycle-outline"
+            label="Motorcycle"
+            value={`${lot.motorcycle_spaces} space${lot.motorcycle_spaces !== 1 ? 's' : ''}`}
+          />
+        )}
+      </View>
+
+      {/* ── Safety & Features (chips) ── */}
+      <View style={[styles.card, { backgroundColor: colors.white, shadowColor: colors.shadowDark }]}>
+        <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>
+          Safety & Features
+        </Text>
+
+        <View style={chipStyles.container}>
+          <AmenityChip
+            icon="bulb-outline"
+            label="Lighting"
+            available={lot.has_lighting}
+          />
+          <AmenityChip
+            icon="videocam-outline"
+            label="Cameras"
+            available={lot.has_cameras}
+          />
+          <AmenityChip
+            icon="call-outline"
+            label="Emergency Phone"
+            available={lot.has_emergency_phone}
+          />
+          <AmenityChip
+            icon="shield-checkmark-outline"
+            label={lot.is_covered ? 'Covered' : 'Open Air'}
+            available={lot.is_covered}
+          />
+          <AmenityChip
+            icon="trail-sign-outline"
+            label={lot.is_paved ? 'Paved' : 'Unpaved'}
+            available={lot.is_paved}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+/* ─── styles ─── */
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.lg,
+    paddingBottom: SPACING.xxxl * 2, // extra room above FAB buttons
+    gap: SPACING.lg,
+  },
+  card: {
+    borderRadius: SPACING.lg,
+    padding: SPACING.xl,
+    shadowOffset: { width: 0, height: SPACING.xs },
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
+    elevation: SPACING.sm,
+  },
+  sectionTitle: {
+    fontSize: TYPOGRAPHY.fontSize.xl,
+    fontWeight: TYPOGRAPHY.fontWeight.semibold,
+    marginBottom: SPACING.lg,
+  },
+});
+
+const rowStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingVertical: SPACING.md,
+  },
+  icon: {
+    width: 24,
+    textAlign: 'center',
+  },
+  label: {
+    fontSize: TYPOGRAPHY.fontSize.md,
+    fontWeight: TYPOGRAPHY.fontWeight.medium,
+    marginLeft: SPACING.md,
+    flex: 1,
+  },
+  value: {
+    fontSize: TYPOGRAPHY.fontSize.md,
+    flexShrink: 1,
+    textAlign: 'right',
+    maxWidth: '55%' as unknown as number,
+  },
+});
+
+const chipStyles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: SPACING.md,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: SPACING.sm,
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.md,
+    borderRadius: SPACING.xl,
+    borderWidth: 1,
+  },
+  label: {
+    fontSize: TYPOGRAPHY.fontSize.sm,
+    fontWeight: TYPOGRAPHY.fontWeight.medium,
+  },
+});

--- a/apps/mobile/src/components/Modals/RecommendationModal.tsx
+++ b/apps/mobile/src/components/Modals/RecommendationModal.tsx
@@ -178,7 +178,7 @@ export function RecommendationModal({
                   </View>
                 </View>
                 <Text style={styles.occupancyText}>
-                  {lot.current_occupancy} / {lot.capacity} spots taken
+                  ~{lot.estimated_occupancy ?? lot.current_occupancy} / {lot.capacity} spots taken
                 </Text>
                 <View style={styles.progressBarBg}>
                   <View
@@ -263,7 +263,7 @@ export function RecommendationModal({
                   </View>
                 </View>
                 <Text style={styles.occupancyText}>
-                  {rec.current_occupancy} / {rec.capacity} spots taken
+                  ~{rec.estimated_occupancy ?? rec.current_occupancy} / {rec.capacity} spots taken
                 </Text>
                 <Text style={styles.reasonText}>
                   {rec.reason}
@@ -416,11 +416,14 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: 'bold',
     color: COLORS.textPrimary,
+    flex: 1,
+    flexShrink: 1,
   },
   pctBadge: {
     paddingHorizontal: 8,
     paddingVertical: 2,
     borderRadius: 10,
+    flexShrink: 0,
   },
   pctBadgeText: {
     fontSize: 12,

--- a/apps/mobile/src/components/Modals/ReliabilityModal.tsx
+++ b/apps/mobile/src/components/Modals/ReliabilityModal.tsx
@@ -170,6 +170,7 @@ const styles = StyleSheet.create({
     borderTopLeftRadius: SPACING.xl,
     borderTopRightRadius: SPACING.xl,
     padding: SPACING.xl,
+    paddingBottom: SPACING.xxxl + SPACING.xl,
     maxHeight: '80%',
   },
   modalHeader: {

--- a/apps/mobile/src/hooks/useAllLotsData.ts
+++ b/apps/mobile/src/hooks/useAllLotsData.ts
@@ -1,8 +1,12 @@
 /**
  * Custom hook for managing all lots data
  */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
 import { lotsApi, ParkingLotResponse } from '../services/api';
+
+/** How often to re-fetch all lots data (ms) */
+const ALL_LOTS_POLL_MS = 30_000; // 30 seconds
 
 interface UseAllLotsDataReturn {
   lots: ParkingLotResponse[];
@@ -30,8 +34,27 @@ export function useAllLotsData(): UseAllLotsDataReturn {
     }
   };
 
+  // Initial fetch + polling
   useEffect(() => {
     fetchLots();
+
+    const interval = setInterval(() => {
+      fetchLots();
+    }, ALL_LOTS_POLL_MS);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  // Re-fetch when the app returns to the foreground
+  const appState = useRef(AppState.currentState);
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (next: AppStateStatus) => {
+      if (appState.current.match(/inactive|background/) && next === 'active') {
+        fetchLots();
+      }
+      appState.current = next;
+    });
+    return () => sub.remove();
   }, []);
 
   return {

--- a/apps/mobile/src/hooks/useLotData.ts
+++ b/apps/mobile/src/hooks/useLotData.ts
@@ -1,8 +1,13 @@
 /**
  * Custom hook for managing lot data and API calls
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
 import { lotsApi, ParkingLotResponse, OccupancyHistoryRecord, ApiError } from '../services/api';
+
+/** How often to re-fetch lot data (ms) */
+const LOT_DETAIL_POLL_MS = 60_000;  // 60 seconds
+const LOTS_LIST_POLL_MS  = 30_000;  // 30 seconds
 
 interface UseLotDataReturn {
   lot: ParkingLotResponse | null;
@@ -73,13 +78,31 @@ export function useLotData(lotId: string): UseLotDataReturn {
     }
   }, [lotId]);
 
-  // Initial data load
+  // Initial data load + polling
   useEffect(() => {
-    if (lotId) {
+    if (!lotId) return;
+
+    refreshLot();
+    refreshHistory();
+
+    const interval = setInterval(() => {
       refreshLot();
-      refreshHistory();
-    }
+    }, LOT_DETAIL_POLL_MS);
+
+    return () => clearInterval(interval);
   }, [lotId, refreshLot, refreshHistory]);
+
+  // Re-fetch when the app returns to the foreground
+  const appState = useRef(AppState.currentState);
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (next: AppStateStatus) => {
+      if (appState.current.match(/inactive|background/) && next === 'active') {
+        refreshLot();
+      }
+      appState.current = next;
+    });
+    return () => sub.remove();
+  }, [refreshLot]);
 
   return {
     lot,
@@ -127,8 +150,27 @@ export function useLotsList(filters?: {
     }
   }, [filters]);
 
+  // Initial fetch + polling
   useEffect(() => {
     refreshLots();
+
+    const interval = setInterval(() => {
+      refreshLots();
+    }, LOTS_LIST_POLL_MS);
+
+    return () => clearInterval(interval);
+  }, [refreshLots]);
+
+  // Re-fetch when the app returns to the foreground
+  const appState = useRef(AppState.currentState);
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (next: AppStateStatus) => {
+      if (appState.current.match(/inactive|background/) && next === 'active') {
+        refreshLots();
+      }
+      appState.current = next;
+    });
+    return () => sub.remove();
   }, [refreshLots]);
 
   return {

--- a/apps/mobile/src/screens/ShortTermForecastScreen.tsx
+++ b/apps/mobile/src/screens/ShortTermForecastScreen.tsx
@@ -19,6 +19,7 @@ import useFavorites from '../hooks/useFavorites';
 
 import {getOccupancyColor} from '../utils/parkingUtils';
 import {HourlyChart} from '../components/HourlyChart';
+import { LotAmenities } from '../components/LotAmenities';
 import { ReportModal } from '../components/Modals/ReportModal';
 import { ReliabilityModal } from '../components/Modals/ReliabilityModal';
 import type { MapStackScreenProps } from '../types/navigation';
@@ -171,6 +172,9 @@ export function ShortTermForecastScreen() {
 
         {/* Chart */}
         <HourlyChart data={forecast}/>
+
+        {/* Lot Amenities & Details */}
+        <LotAmenities lot={lot} />
       </ScrollView>
 
       {/* Report Button */}

--- a/apps/mobile/src/services/api/lots.ts
+++ b/apps/mobile/src/services/api/lots.ts
@@ -46,6 +46,14 @@ export interface ParkingLotResponse extends ParkingLot {
   available: number;
   occupancy_rate: number;
   fill_status: 'AVAILABLE' | 'FILLING' | 'NEARLY_FULL' | 'FULL';
+  /** Estimated true occupancy (scaled up from raw device count) */
+  estimated_occupancy: number;
+  /** Estimated available spots (capacity - estimated_occupancy) */
+  estimated_available: number;
+  /** Raw device count (current_occupancy before scaling) */
+  raw_occupancy: number;
+  /** Effective penetration rate used for estimation (0.01–1.0) */
+  effective_penetration_rate: number;
 }
 
 export interface OccupancySummary {

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -358,12 +358,19 @@ CREATE TABLE occupancy_snapshots (
   available     INTEGER NOT NULL,
   occupancy_rate DOUBLE PRECISION NOT NULL, -- 0.0 to 1.0
   confidence    TEXT NOT NULL CHECK (confidence IN ('LOW', 'MEDIUM', 'HIGH')),
-  reliability_score INTEGER,               -- 0-100
+  reliability_score DOUBLE PRECISION,      -- 0-100
   is_cold_start BOOLEAN DEFAULT FALSE,
-  academic_period TEXT NOT NULL DEFAULT 'regular'
-    CHECK (academic_period IN ('regular', 'finals', 'break', 'summer')),
+
+  -- Penetration rate estimation columns
+  estimated_occupancy    INTEGER,          -- Scaled-up occupancy estimate
+  penetration_rate_used  DOUBLE PRECISION, -- Effective penetration rate at snapshot time
+
+  -- ML feature columns (populated at write time by academic-calendar.ts)
+  semester        TEXT,                    -- fall | spring | summer | session | break
+  academic_period TEXT,                    -- early | regular | midterms | late | dead_week | finals | break
+  week_of_semester INTEGER,               -- 0-16
   is_campus_open BOOLEAN NOT NULL DEFAULT TRUE,
-  week_of_semester INTEGER DEFAULT 0,      -- 0-16
+
   PRIMARY KEY (id),
   FOREIGN KEY (school_id, lot_id) REFERENCES lots(school_id, lot_id)
 );
@@ -380,27 +387,6 @@ CREATE TABLE campus_events (
   expected_attendance INTEGER,
   created_at    TIMESTAMPTZ DEFAULT NOW(),
   PRIMARY KEY (id)
-);
-
--- Academic calendar config
-CREATE TABLE academic_calendar (
-  id            BIGINT GENERATED ALWAYS AS IDENTITY,
-  school_id     TEXT NOT NULL REFERENCES schools(school_id),
-  period_name   TEXT NOT NULL,             -- 'Spring 2026', 'Spring Break', etc.
-  period_type   TEXT NOT NULL CHECK (period_type IN ('regular', 'finals', 'break', 'summer')),
-  start_date    DATE NOT NULL,
-  end_date      DATE NOT NULL,
-  PRIMARY KEY (id)
-);
-
--- Holidays / campus closures
-CREATE TABLE campus_closures (
-  id            BIGINT GENERATED ALWAYS AS IDENTITY,
-  school_id     TEXT NOT NULL REFERENCES schools(school_id),
-  closure_date  DATE NOT NULL,
-  reason        TEXT,
-  PRIMARY KEY (id),
-  UNIQUE (school_id, closure_date)
 );
 
 -- Short-term predictions (overwritten every 15 min)
@@ -447,7 +433,7 @@ CREATE INDEX idx_events_device ON occupancy_events(device_hash, lot_id, timestam
 
 -- Snapshots for ML training queries
 CREATE INDEX idx_snapshots_lot_time ON occupancy_snapshots(school_id, lot_id, timestamp DESC);
-CREATE INDEX idx_snapshots_training ON occupancy_snapshots(school_id, lot_id, academic_period, timestamp);
+CREATE INDEX idx_snapshots_training ON occupancy_snapshots(school_id, lot_id, semester, academic_period, timestamp);
 
 -- Predictions lookup (primary read path)
 CREATE INDEX idx_pred_short ON predictions_short_term(school_id, lot_id);
@@ -479,9 +465,12 @@ SELECT
   s.occupancy,
   s.occupancy_rate,
   s.confidence,
+  s.semester,
   s.academic_period,
   s.is_campus_open,
   s.week_of_semester,
+  s.estimated_occupancy,
+  s.penetration_rate_used,
   EXTRACT(dow FROM s.timestamp) AS day_of_week,
   EXTRACT(hour FROM s.timestamp) AS hour,
   l.lot_type,
@@ -655,7 +644,7 @@ EventBridge (cron) → Lambda (ML inference)
 ```
 EventBridge (cron) → Lambda (ML inference)
                         │
-                        ├── 1. Query occupancy_snapshots + academic_calendar
+                        ├── 1. Query occupancy_snapshots
                         ├── 2. Compute historical baselines (SQL window functions)
                         ├── 3. Run XGBoost adjustment model
                         └── 4. UPSERT predictions_long_term
@@ -719,8 +708,7 @@ SELECT * FROM lots WHERE school_id = 'csuf';
 - [x] Rewrite `ReliabilityComputationService` — SQL aggregations
 
 ### Phase 3: ML Integration (Week 5-6)
-- [x] Add `academic_calendar` and `campus_closures` tables + seed data
-- [x] Add `occupancy_snapshots` with ML features (`academic_period`, `week_of_semester`, `is_campus_open`)
+- [x] Add `occupancy_snapshots` with ML features (`semester`, `academic_period`, `week_of_semester`, `is_campus_open`)
 - [x] Add `predictions_short_term` and `predictions_long_term` tables
 - [ ] Build ML training data queries (direct SQL)
 

--- a/services/ml/Model_Design.md
+++ b/services/ml/Model_Design.md
@@ -72,9 +72,13 @@ CREATE TABLE occupancy_snapshots (
   reliability_score FLOAT,
   is_cold_start     BOOLEAN,
 
-  -- ML feature columns (populated at write time)
-  semester          TEXT,                  -- "fall", "spring", "summer", "break"
-  academic_period   TEXT,                  -- "early", "regular", "midterm", "finals", "break"
+  -- Penetration rate estimation columns
+  estimated_occupancy    INT,              -- Scaled-up occupancy estimate
+  penetration_rate_used  FLOAT,            -- Effective penetration rate at snapshot time
+
+  -- ML feature columns (populated at write time by academic-calendar.ts)
+  semester          TEXT,                  -- fall | spring | summer | session | break
+  academic_period   TEXT,                  -- early | regular | midterms | late | dead_week | finals | break
   week_of_semester  INT,
   is_campus_open    BOOLEAN DEFAULT TRUE
 );
@@ -123,8 +127,8 @@ The ML pipeline also reads from these operational tables:
 | `lots` | Lot metadata & capacity | `lot_id`, `capacity`, `current_occupancy`, `lot_type`, `penetration_rate`, `confidence` |
 | `campus_events` + `event_impacts` | Event-aware features | `event_type` (ATHLETIC \| ACADEMIC \| PERFORMANCE \| OTHER), `expected_attendance`, `impact_level`, `expected_increase_percent` |
 | `weather` | Weather features | `temperature_f`, `humidity_percent`, `wind_speed_mph`, `precipitation_probability`, `is_raining` |
-| `academic_calendar` | Period classification | `semester` (FALL \| SPRING \| SUMMER \| SESSION \| BREAK), `period_type` (EARLY \| REGULAR \| MIDTERMS \| LATE \| DEAD_WEEK \| FINALS), `start_date`, `end_date` |
-| `campus_closures` | `is_campus_open` flag | `date`, `reason` |
+| `academic_calendar` | Period classification | `semester`, `period_type`, `week_of_semester` — provided by `academic_calendar.py` |
+| `campus_closures` | `is_campus_open` flag | `is_campus_open(date)` — provided by `academic_calendar.py` |
 
 ## Model Rationale
 


### PR DESCRIPTION
## Summary

This PR introduces a **penetration rate estimation system** that converts raw device counts into real-occupancy estimates, adds a **TypeScript academic calendar module** for ML feature computation, adds a **lot amenities detail view** in the mobile app, implements **polling and AppState refresh** for real-time data, fixes **UI layout bugs**, and significantly **expands test coverage** across both backend and mobile.

---

## Backend: Penetration Rate Estimation

### Three-Layer Estimation Service (penetration-estimation.service.ts)
1. **Academic calendar base rate**: derives expected daily commuters from the current semester/period (fall: 35K, spring: 34K, summer: 8K, session: 3K, break: 1.5K)
2. **Timezone-aware time multipliers**: adjusts commuters by time-of-day and day-of-week, with campus closure detection
3. **Activity-based scaling caps**: limits scaling factor based on campus-wide device activity to prevent over-inflation when few devices are active

Uses raw SQL `COUNT(DISTINCT device_hash)` for efficient device counting. Includes an empty-lot floor to prevent 0% estimates for lots that simply lack app users.

### Academic Calendar Module (academic-calendar.ts)
- TypeScript port of academic_calendar.py — pure rule-based heuristics, no database tables
- Computes semester dates dynamically using CSULB's scheduling patterns (fall = 4th Monday of August, spring = Tuesday after MLK Day, etc.)
- Exports `getSemester()`, `getWeekOfSemester()`, `isCampusOpen()`, `getExpectedCommuters()`, and more
- 86 unit tests covering all public APIs, multi-year consistency (2020–2027), and federal observed-holiday edge cases

### Snapshot ML Feature Columns
- `createSnapshots()` now populates `semester`, `academic_period`, `week_of_semester`, and `is_campus_open` at write time
- Values are lowercase strings matching the Python ML pipeline convention (e.g., `fall`, `regular`, `midterms`)
- ML training reads these pre-computed columns directly — no recomputation needed

### Database Changes
- Migration: `20260308045807_add_penetration_estimation` — adds `estimated_occupancy`, `penetration_rate_used`, `semester`, `academic_period`, `week_of_semester` to `occupancy_snapshots`
- Migration: `20260308200000_remove_calendar_tables` — drops `academic_calendar`, `campus_closures`, `campus_activity_baselines` tables (replaced by algorithmic computation)

### Service Integration
- `LotsService` returns `estimated_occupancy`, `estimated_available`, `raw_occupancy`, and `effective_penetration_rate` in `ParkingLotResponse`
- Lots service uses estimation-first filtering (e.g., `min_available` uses estimated values)
- `OccupancyEventsService` computes calendar features once per snapshot batch
- `PenetrationEstimationService` wired into both `LotsModule` and `OccupancyEventsModule`

### Seed Data
- Scaled all 28 lots' `current_occupancy` to raw device counts (`real_occupancy × penetration_rate`)
- Seeded 1,500 unique deterministic device hashes distributed proportionally across lots

---

## Mobile: Lot Amenities Detail View

### New `LotAmenities` Component
- Shows 5 info sections: lot overview, permits & rates, hours, special spaces (EV charging, accessible, motorcycle), and safety features
- Renders features as styled chips with conditional display logic
- Integrated below the hourly chart in `ShortTermForecastScreen`

---

## Mobile: Polling & Real-Time Data

- `useLotsList` / `useAllLotsData`: 30-second polling interval with `AppState` foreground refresh
- `useLotData`: 60-second polling interval with `AppState` foreground refresh
- Added `estimated_occupancy`, `estimated_available`, `raw_occupancy`, and `effective_penetration_rate` to `ParkingLotResponse` type
- Updated `MapScreen` and `RecommendationModal` tests for the new response shape

---

## Mobile: UI Bug Fixes

- **RecommendationModal**: Added `flex`/`flexShrink` to lot name and percentage badge so long names (e.g., "Pyramid Parking Structure") truncate instead of pushing the badge offscreen
- **ReliabilityModal**: Increased bottom padding to clear the iPhone home indicator

---

**Tests**: Backend 320 tests (19 suites) · Mobile 220 tests (21 suites)