### PR TITLE
Android bluetooth permission error not caught

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/mobile/carbluetooth/CarBluetoothModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/mobile/carbluetooth/CarBluetoothModule.kt
@@ -117,9 +117,9 @@ class CarBluetoothModule(reactContext: ReactApplicationContext) :
     private fun checkInitialState() {
         val adapter = BluetoothAdapter.getDefaultAdapter() ?: return
         // Check A2DP profile connection state
-        try {
-            adapter.getProfileProxy(reactApplicationContext, object : BluetoothProfile.ServiceListener {
-                override fun onServiceConnected(profile: Int, proxy: BluetoothProfile) {
+        adapter.getProfileProxy(reactApplicationContext, object : BluetoothProfile.ServiceListener {
+            override fun onServiceConnected(profile: Int, proxy: BluetoothProfile) {
+                try {
                     val devices = proxy.connectedDevices
                     if (devices.isNotEmpty()) {
                         isCarConnected = true
@@ -127,13 +127,14 @@ class CarBluetoothModule(reactContext: ReactApplicationContext) :
                             connectedProfiles.add("a2dp:${device.address}")
                         }
                     }
+                } catch (_: SecurityException) {
+                    // BLUETOOTH_CONNECT not granted at runtime — isCarConnected stays false
+                } finally {
                     adapter.closeProfileProxy(profile, proxy)
                 }
-                override fun onServiceDisconnected(profile: Int) {}
-            }, BluetoothProfile.A2DP)
-        } catch (_: SecurityException) {
-            // BLUETOOTH_CONNECT permission not granted — isCarConnected stays false
-        }
+            }
+            override fun onServiceDisconnected(profile: Int) {}
+        }, BluetoothProfile.A2DP)
     }
 
     // ── Event emission ────────────────────────────────────────────────────────


### PR DESCRIPTION
# Bluetooth permission error not caught

## Summary
On Android 12+, apps must explicitly ask the user for permission to see paired Bluetooth devices. If the user hasn't granted that permission yet, the app is supposed to silently do nothing. When permission is denied, Android throws a `SecurityException`. 
- The safety net catching that error was placed in the wrong spot, before an async operation completed. The unhandled error caused the app to crash on startup.

## Why
Android requires the `BLUETOOTH_CONNECT` runtime permission  to access connected Bluetooth devices. iOS handles this differently via CoreBluetooth and is unaffected. On Android, the permission check happens inside an async callback, so the error handler was in the wrong place and never triggered, and a resource leak occurred when permission was denied. The fix moves it to where it's needed.
