### PR TITLE
ci(deploy): auto-deploy backend to Fly on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to Fly
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/backend/**"
+      - "packages/types/**"
+      - "packages/utils/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/deploy.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: fly-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: fly deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy
+        working-directory: apps/backend
+        run: flyctl deploy --remote-only --config fly.toml


### PR DESCRIPTION
Adds .github/workflows/deploy.yml so merges to main automatically run `fly deploy` for the backend.

- Path-filtered (apps/backend, packages/types, packages/utils, pnpm-lock.yaml) so mobile-only changes don't redeploy
- Uses `--remote-only` (no local builder needed)
- Concurrency group `fly-deploy` prevents overlapping deploys
- `workflow_dispatch` for manual triggers
- 15min timeout cap

Requires `FLY_API_TOKEN` repo secret (already added).