### PR TITLE
fix(deploy): run flyctl from repo root

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,5 +26,4 @@ jobs:
       - uses: actions/checkout@v5
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy
-        working-directory: apps/backend
-        run: flyctl deploy --remote-only --config fly.toml
+        run: flyctl deploy --remote-only --config apps/backend/fly.toml --dockerfile apps/backend/Dockerfile


### PR DESCRIPTION
Follow-up to #90. The deploy workflow ran `flyctl` from `apps/backend/`, which scoped Depot's build context to that subdir. The Dockerfile expects the monorepo root (it COPYs `pnpm-workspace.yaml`, `packages/`, `apps/backend/`), so all those COPYs failed with `not found`.

Run from repo root with explicit `--config` and `--dockerfile` paths so the build context = repo root.