### PR TITLE
fix(deploy): migrate from CI runner, not Fly release_command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/deploy.yml"
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: fly-deploy
   cancel-in-progress: false
@@ -24,6 +27,46 @@ jobs:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:
       - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.20.0
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install backend deps
+        run: pnpm install --filter @sharkpark/backend... --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm db:generate
+
+      - name: Run Prisma migrations
+        env:
+          NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+          # Concurrency group above serializes deploys, so we don't need
+          # Prisma's advisory lock (which would fail on pgbouncer anyway).
+          PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK: "1"
+        run: |
+          # Force pooled endpoint (always reachable; direct endpoint can be
+          # suspended on Neon free tier) and add pgbouncer=true so Prisma uses
+          # the simple protocol that survives transaction-mode pooling.
+          DATABASE_URL=$(node -e '
+            const u = new URL(process.env.NEON_DATABASE_URL);
+            if (!u.hostname.includes("-pooler.")) {
+              u.hostname = u.hostname.replace(/^(ep-[^.]+)\./, "$1-pooler.");
+            }
+            u.searchParams.set("pgbouncer", "true");
+            u.searchParams.set("connection_limit", "1");
+            u.searchParams.set("connect_timeout", "60");
+            console.log(u.toString());
+          ')
+          export DATABASE_URL
+          echo "Migrating against pooled endpoint: ${DATABASE_URL%%@*}@***"
+          pnpm db:deploy
+
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy
         run: flyctl deploy --remote-only --config apps/backend/fly.toml --dockerfile apps/backend/Dockerfile

--- a/apps/backend/fly.toml
+++ b/apps/backend/fly.toml
@@ -16,10 +16,12 @@ primary_region = 'lax'
   dockerfile = 'Dockerfile'
 
 [deploy]
-  # Run pending Prisma migrations against Neon before swapping in the new
-  # release. `prisma` is a runtime dep so the CLI is on the pruned image.
+  # Migrations run from the GitHub Actions runner (see .github/workflows/deploy.yml)
+  # before flyctl deploy. The CI runner has stable connectivity to Neon's pooler,
+  # whereas the release_command machine on Fly intermittently fails to reach the
+  # direct endpoint when the Neon compute is suspended. The deploy workflow's
+  # concurrency group serializes deploys, so we don't need Prisma's advisory lock.
   strategy = 'rolling'
-  release_command = 'npx prisma migrate deploy'
 
 [env]
   HOST = '0.0.0.0'


### PR DESCRIPTION
## Problem

The Fly release_command machine intermittently fails to reach Neon's direct (non-pooler) endpoint when the compute is suspended on the free tier:

```
Error: P1001: Can't reach database server at `ep-silent-truth-ak3kf1vw.c-3.us-west-2.aws.neon.tech:5432`
```

Even after staging `connect_timeout=30` on `DIRECT_URL`, the release machine times out at 60s without a TCP handshake. The pooled endpoint (`-pooler.`) accepts connections fine and auto-wakes the compute.

## Fix

Move `prisma migrate deploy` out of `release_command` and into the deploy workflow:

- Force the pooled hostname so we never hit the suspendable direct endpoint
- `pgbouncer=true` + `connection_limit=1` so Prisma uses the simple protocol that survives transaction-mode pooling
- `PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK=1` because pgbouncer transaction mode breaks session-scoped advisory locks; workflow concurrency group already serializes deploys
- `connect_timeout=60` for headroom

Drops `release_command` from fly.toml. Fly only sees the new image; migrations run in CI with clear logs and stable network.