### PR TITLE
fix(backup): pg_dump uses OS trust store for Neon SSL

### DIFF
--- a/apps/backend/src/scripts/backup-db.ts
+++ b/apps/backend/src/scripts/backup-db.ts
@@ -49,7 +49,13 @@ void runCronJob('backup-db', async ({ logger }) => {
       '--compress=0', // we gzip the stream ourselves
       dbUrl,
     ],
-    { stdio: ['ignore', 'pipe', 'pipe'] },
+    {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      // Neon URLs use sslmode=verify-full. The runtime image doesn't ship a
+      // ~/.postgresql/root.crt, so point libpq at the OS trust store
+      // (Debian's ca-certificates bundle) instead.
+      env: { ...process.env, PGSSLROOTCERT: 'system' },
+    },
   );
 
   // Capture stderr for diagnostics; pg_dump emits informational messages here.


### PR DESCRIPTION
## Problem

Manual P7.10 backup smoke test failed with:

```
pg_dump: error: ... root certificate file "/root/.postgresql/root.crt" does not exist
```

The runtime image doesn't ship a per-user libpq cert bundle, but Neon's URL forces `sslmode=verify-full`.

## Fix

Set `PGSSLROOTCERT=system` on the `pg_dump` spawn env so libpq uses Debian's `ca-certificates` bundle. Doesn't touch `DIRECT_URL`, doesn't downgrade SSL.