### PR TITLE
chore: drop runtime SSL workarounds; configure via URL

### DIFF
--- a/apps/backend/prisma/seed-prod.ts
+++ b/apps/backend/prisma/seed-prod.ts
@@ -33,26 +33,12 @@ import { PrismaPg } from '@prisma/adapter-pg';
 import pg from 'pg';
 import { CSULB_SCHOOL, GEOFENCE_POLYGONS, generateGeofence, parkingLots } from './lot-data';
 
-const rawConnectionString = process.env.DATABASE_URL;
-if (!rawConnectionString) {
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
   console.error('[seed-prod] DATABASE_URL is not set. Aborting.');
   process.exit(1);
 }
 
-/**
- * Normalize sslmode to `verify-full` to silence pg's deprecation warning
- * about treating `require`/`prefer`/`verify-ca` as aliases for `verify-full`
- * in pg v9. Neon issues real certs, so verify-full is the correct mode.
- */
-function normalizeSslMode(url: string): string {
-  if (/[?&]sslmode=verify-full(\b|&)/i.test(url)) return url;
-  if (/[?&]sslmode=(require|prefer|verify-ca)\b/i.test(url)) {
-    return url.replace(/([?&])sslmode=(require|prefer|verify-ca)\b/i, '$1sslmode=verify-full');
-  }
-  return url + (url.includes('?') ? '&' : '?') + 'sslmode=verify-full';
-}
-
-const connectionString = normalizeSslMode(rawConnectionString);
 const pool = new pg.Pool({ connectionString });
 const adapter = new PrismaPg(pool);
 const prisma = new PrismaClient({ adapter });


### PR DESCRIPTION
## Summary

`NEON_DATABASE_URL` (GitHub Actions) and `DIRECT_URL` (Fly) secrets were just updated to embed:

```
?sslmode=verify-full&sslrootcert=system&channel_binding=require&connect_timeout=30
```

That makes the URL self-describing: every libpq / pg consumer (pg_dump, node-postgres) gets the correct SSL config without any code touching the URL string.

## Removed

- `normalizeSslMode()` in `prisma/seed-prod.ts` — it rewrote `sslmode=require` → `verify-full` to silence pg v9's deprecation. The secret already has `verify-full`, so it was a no-op.

## Not touched (intentional)

- The `-pooler` / `pgbouncer=true` / advisory-lock-disable transforms in `deploy.yml` — those address pooling mode, not SSL, and are still required.