### PR TITLE
chore: drop runtime SSL workarounds; configure via URL

### DIFF
--- a/apps/backend/prisma/seed-prod.ts
+++ b/apps/backend/prisma/seed-prod.ts
@@ -33,13 +33,27 @@ import { PrismaPg } from '@prisma/adapter-pg';
 import pg from 'pg';
 import { CSULB_SCHOOL, GEOFENCE_POLYGONS, generateGeofence, parkingLots } from './lot-data';
 
-const connectionString = process.env.DATABASE_URL;
-if (!connectionString) {
+const rawConnectionString = process.env.DATABASE_URL;
+if (!rawConnectionString) {
   console.error('[seed-prod] DATABASE_URL is not set. Aborting.');
   process.exit(1);
 }
 
-const pool = new pg.Pool({ connectionString });
+/**
+ * `sslrootcert=system` is a libpq feature (uses the OS CA bundle). node-postgres
+ * doesn't recognize it and tries to fs.readFileSync('system') → ENOENT. Strip
+ * it: Node's TLS already trusts system roots by default, so verify-full still
+ * does full chain + hostname verification.
+ */
+function stripLibpqOnlyParams(url: string): string {
+  const u = new URL(url);
+  if (u.searchParams.get('sslrootcert') === 'system') {
+    u.searchParams.delete('sslrootcert');
+  }
+  return u.toString();
+}
+
+const pool = new pg.Pool({ connectionString: stripLibpqOnlyParams(rawConnectionString) });
 const adapter = new PrismaPg(pool);
 const prisma = new PrismaClient({ adapter });
 
@@ -85,7 +99,7 @@ function lotNeedsUpdate(
 
 async function seedProd() {
   console.log('[seed-prod] SharkPark production seed (idempotent)\n');
-  console.log(`[seed-prod] DATABASE host: ${new URL(connectionString!).host}\n`);
+  console.log(`[seed-prod] DATABASE host: ${new URL(rawConnectionString!).host}\n`);
 
   // ── 1. Upsert School ───────────────────────────────────────
   const beforeSchool = await prisma.school.findUnique({


### PR DESCRIPTION
## Summary
`NEON_DATABASE_URL` (GitHub Actions) and `DIRECT_URL` (Fly) secrets now embed:

```
?sslmode=verify-full&sslrootcert=system&channel_binding=require&connect_timeout=30
```

So every libpq consumer (pg_dump in backup-db) gets the right SSL config without code touching the URL.

## Changes

- `prisma/seed-prod.ts`:
  - Drop the `normalizeSslMode()` helper — secret already has `verify-full`.
  - Add a tiny `stripLibpqOnlyParams()` that removes `sslrootcert=system` before constructing `pg.Pool`. node-postgres doesn't recognize the special `system` value (libpq-only) and would try `fs.readFileSync('system')`. Node's TLS already trusts system CAs by default, so `sslmode=verify-full` still gives full chain + hostname verification.

## Not touched (intentional)

- `-pooler` / `pgbouncer=true` / advisory-lock-disable in `deploy.yml` — pooling concerns, not SSL.
- `backup-db.ts` — clean on main; libpq picks up `sslrootcert=system` natively.

## Validation

After merge, P7.10 backup smoke test:
```
fly ssh console -a sharkpark-api -g cron -C 'node /app/apps/backend/dist/scripts/backup-db.js'
```