### PR TITLE
feat(mobile): add Delete Account UI in ProfileScreen (App Store 5.1.1…

### DIFF
--- a/apps/mobile/src/auth/index.ts
+++ b/apps/mobile/src/auth/index.ts
@@ -1,2 +1,2 @@
-export { loginWithAzure } from './AzureAuth';
-export { logoutFromAzure } from './AzureAuth';
+export { loginWithAzure, logoutFromAzure, loadAuth, saveAuth } from './AzureAuth';
+export type { AuthResult } from './AzureAuth';

--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -16,6 +16,7 @@ import { useEnhancedGeofencing } from '../context/EnhancedGeofencingProvider';
 import { TYPOGRAPHY, SPACING, COLORS } from '../constants/theme';
 import { useTheme } from '../context/ThemeContext';
 import { useAuth } from '../context/AuthContext';
+import { deleteMyAccount } from '../services/api/users';
 
 const ProfileScreen: React.FC = () => {
   const { themeMode, setThemeMode, colors } = useTheme();
@@ -100,6 +101,31 @@ const ProfileScreen: React.FC = () => {
           onPress: () => {logout()},
         },
       ]
+    );
+  };
+
+  const handleDeleteAccount = () => {
+    Alert.alert(
+      'Delete Account',
+      'This permanently deletes your account, favorites, and reports. This action cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete Account',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await deleteMyAccount();
+              await logout();
+            } catch (error) {
+              Alert.alert(
+                'Error',
+                error instanceof Error ? error.message : 'Failed to delete account. Please try again.',
+              );
+            }
+          },
+        },
+      ],
     );
   };
 
@@ -267,6 +293,17 @@ const ProfileScreen: React.FC = () => {
           <Text style={[styles.logoutButtonText, { color: colors.errorText }]}>Logout</Text>
           </TouchableOpacity>
 
+          {/* Delete Account Button */}
+          <TouchableOpacity
+            style={[styles.deleteAccountButton, { borderColor: colors.errorBorder }]}
+            onPress={handleDeleteAccount}
+          >
+            <Icon name="trash-outline" size={18} color={colors.errorText} />
+            <Text style={[styles.deleteAccountText, { color: colors.errorText }]}>
+              Delete Account
+            </Text>
+          </TouchableOpacity>
+
         {/* Development Test Button */}
         {__DEV__ && GeofencingTestButton && <GeofencingTestButton />}
         
@@ -371,6 +408,20 @@ const styles = StyleSheet.create({
     fontSize: TYPOGRAPHY.fontSize.md,
     fontFamily: TYPOGRAPHY.fontFamily.semibold,
     marginLeft: SPACING.md,
+  },
+  deleteAccountButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: SPACING.lg,
+    borderRadius: SPACING.lg,
+    borderWidth: 1,
+    marginTop: SPACING.sm,
+  },
+  deleteAccountText: {
+    fontSize: TYPOGRAPHY.fontSize.sm,
+    fontFamily: TYPOGRAPHY.fontFamily.medium,
+    marginLeft: SPACING.sm,
   },
   statusBadge: {
     paddingHorizontal: 12,

--- a/apps/mobile/src/services/api/users.ts
+++ b/apps/mobile/src/services/api/users.ts
@@ -4,7 +4,7 @@
  */
 
 import { apiService } from './base';
-import { loadAuth } from '../../auth/AzureAuth';
+import { loadAuth } from '../../auth';
 
 /**
  * Permanently deletes the authenticated user's account.

--- a/apps/mobile/src/services/api/users.tsx
+++ b/apps/mobile/src/services/api/users.tsx
@@ -1,0 +1,30 @@
+/**
+ * Users API Service
+ * Handles user-account operations against the backend.
+ */
+
+import { apiService } from './base';
+import { loadAuth } from '../../auth/AzureAuth';
+
+/**
+ * Permanently deletes the authenticated user's account.
+ * Maps to DELETE /api/v1/users/me (PR #100).
+ *
+ * The endpoint is protected by the Azure AD JWT middleware — the caller's
+ * idToken must be forwarded as a Bearer token so the backend can resolve
+ * req.user.email.
+ *
+ * After this resolves, callers should invoke logout() to clear local state.
+ */
+export async function deleteMyAccount(): Promise<void> {
+  const auth = await loadAuth();
+  if (!auth?.idToken) {
+    throw new Error('No authenticated session found.');
+  }
+
+  await apiService.delete<void>('/users/me', {
+    headers: {
+      Authorization: `Bearer ${auth.idToken}`,
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Adds a **Delete Account** option to the Profile screen, satisfying [Apple App Store Guideline 5.1.1(v)](https://developer.apple.com/app-store/review/guidelines/#data-collection-and-storage) which requires apps to offer in-app account deletion.

## Changes

- `apps/mobile/src/services/api/users.tsx` *(new)* — `deleteMyAccount()` calls `DELETE /api/v1/users/me` with the stored `idToken` as a Bearer token
- `apps/mobile/src/screens/ProfileScreen.tsx` — adds `handleDeleteAccount()` with a confirm modal and a "Delete Account" button below the Logout button

## Behavior

1. User taps **Delete Account** on the Profile screen
2. A confirmation modal appears:
   > *"This permanently deletes your account, favorites, and reports. This action cannot be undone."*
3. On confirm → calls `DELETE /api/v1/users/me` → calls `logout()` → clears local state → routes to Login screen
4. On error → shows an error alert with the failure message

## Notes

- Depends on the `DELETE /users/me` endpoint (PR #100)
- Button is intentionally lower visual weight than Logout (border-only, smaller font) to reduce