### PR TITLE
chore(backend): allow jose ESM through Jest transform

### DIFF
--- a/apps/backend/jest-e2e.js
+++ b/apps/backend/jest-e2e.js
@@ -4,8 +4,14 @@ module.exports = {
   moduleFileExtensions: ["js", "json", "ts"],
   testRegex: ".*\\.e2e-spec\\.ts$",
   transform: {
-    "^.+\\.(t|j)s$": "ts-jest"
+    // ts-jest needs `allowJs` to transpile jose's ESM `.js` source down to
+    // CJS for the Jest runtime (see transformIgnorePatterns below).
+    "^.+\\.(t|j)s$": ["ts-jest", { tsconfig: { allowJs: true } }],
   },
+  // jose v6 (transitive dep of jwks-rsa >=4) ships ESM only. By default Jest
+  // skips transforming anything in node_modules, so its `export` syntax
+  // crashes the CJS test runner. Allow jose through the transform.
+  transformIgnorePatterns: ["/node_modules/(?!jose/)"],
   setupFiles: ["dotenv/config"],
   // Fail fast instead of hanging on stray open handles (Sentry background
   // flush loop, pino transports, etc.). Each test is capped at 30s; the

--- a/apps/backend/jest.config.js
+++ b/apps/backend/jest.config.js
@@ -4,8 +4,14 @@ module.exports = {
   moduleFileExtensions: ["js", "json", "ts"],
   testRegex: ".*\\.spec\\.ts$",
   transform: {
-    "^.+\\.(t|j)s$": "ts-jest"
+    // ts-jest needs `allowJs` to transpile jose's ESM `.js` source down to
+    // CJS for the Jest runtime (see transformIgnorePatterns below).
+    "^.+\\.(t|j)s$": ["ts-jest", { tsconfig: { allowJs: true } }],
   },
+  // jose v6 (transitive dep of jwks-rsa >=4) ships ESM only. By default Jest
+  // skips transforming anything in node_modules, so its `export` syntax
+  // crashes the CJS test runner. Allow jose through the transform.
+  transformIgnorePatterns: ["/node_modules/(?!jose/)"],
   coverageDirectory: "./coverage",
   collectCoverageFrom: [
     "src/**/*.ts",


### PR DESCRIPTION
## Why

`jwks-rsa@4` pulls in **jose v6**, which is ESM-only — its `exports` map only points at `dist/webapi/index.js` with `"type": "module"` and there is no CJS condition. Jest's default CJS runtime hits the file's `export` syntax and crashes:

```
/node_modules/jose/dist/webapi/index.js:1
export { compactDecrypt } from './jwe/compact/decrypt.js';
^^^^^^
SyntaxError: Unexpected token 'export'
  at .../jwks-rsa/src/index.js:1
  at src/auth/azure.strategy.ts:4
  at src/auth/auth.module.ts:4
  at src/app.module.ts:9
```

This blocks **PR #670** (Dependabot bump `jwks-rsa` 3.2.2 → 4.0.1) and breaks every e2e suite + the auth unit specs whenever jwks-rsa is on v4.

## What

Two-line fix in both Jest configs:

1. `transformIgnorePatterns: ["/node_modules/(?!jose/)"]` — let Jest transform jose instead of skipping it.
2. Inline ts-jest config sets `allowJs: true` so the .js sources actually compile down to CJS for the runtime, without polluting the build tsconfig.

`customExportConditions` was tried first and is a dead end — jose v6 has no node/CJS condition to pick.

## Verified locally

Installed `jwks-rsa@4.0.1` + `jose@6.2.3` and ran:

- `pnpm test` (auth specs) → **13/13 pass**
- `jest --config jest-e2e.js` (app.e2e-spec) → **2/2 pass**

Lockfile reverted to main; only the two jest configs are modified.

## Unblocks

- #670 (jwks-rsa 3.2.2 → 4.0.1)
- Any future bump that pulls in pure-ESM transitive deps.
