### PR TITLE
ci(ios): drop prefix restore-keys on Pods cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,13 +111,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
+      # NOTE: exact-match only (no restore-keys). Pods/Local Podspecs is keyed
+      # by Podfile.lock content; restoring a stale prefix-matched cache from a
+      # different lockfile makes `pod install` fail with "version of the
+      # dependency ... differs from the version stored in `Pods/Local Podspecs`"
+      # (e.g. when a PR's RN version differs from a previously-cached one).
       - name: Cache CocoaPods
         uses: actions/cache@v5
         with:
           path: apps/mobile/ios/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('apps/mobile/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Problem

`ios-build` on PR #137 (and any future PR whose RN version differs from the most-recently-cached build) fails with:

```
[!] CocoaPods could not find compatible versions for pod "hermes-engine":
  In snapshot (Podfile.lock):
    hermes-engine (= 0.82.1, ...)
  In Podfile:
    hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)

Specs satisfying the `hermes-engine (= 0.82.1, ...), hermes-engine (from ...)` dependency
were found, but they required a higher minimum deployment target.
```

…because `Pods/Local Podspecs/hermes-engine.podspec.json` actually contains version `0.85.2` while `Podfile.lock` pins `0.82.1`.

## Root cause

The `Cache CocoaPods` step had:

```yaml
key: ${{ runner.os }}-pods-${{ hashFiles('apps/mobile/ios/Podfile.lock') }}
restore-keys: |
  ${{ runner.os }}-pods-
```

`Pods/Local Podspecs/` is content-addressed by the lockfile — each `Podfile.lock` produces a podspec set that is only valid for that exact lockfile. The greedy `restore-keys` prefix matches *any* prior `macOS-pods-*` cache entry on a hash miss, splatting an older RN's `Local Podspecs/` over the freshly-installed `node_modules`. `pod install` then refuses to proceed because the podspec on disk disagrees with the lockfile.

Sequence that triggered it:

1. PR #135 bumped RN `0.82.1 → 0.85.2`; CI saved Pods cache at `macOS-pods-<hashA>` (hermes 0.85.2).
2. PR #120 merged with stale base and silently reverted RN back to `0.82.1`; new lockfile hash `<hashB>`.
3. Subsequent PRs miss `<hashB>`, but `restore-keys: macOS-pods-` happily restores the `<hashA>` cache → `Local Podspecs/hermes-engine.podspec.json` = 0.85.2, `Podfile.lock` = 0.82.1 → fail.

## Fix

Make the Pods cache **exact-match only**. On a lockfile change CI does a fresh `pod install` (slower for that one run, correct every run thereafter). The Turbo cache step is unaffected.

## Verification

- Diff is a 3-line removal under `Cache CocoaPods` only.
- `lint` + `typecheck` clean locally (pre-commit hook ran).
- The `key:` already includes `hashFiles('apps/mobile/ios/Podfile.lock')`, so a hit on the new key is guaranteed safe; misses now correctly rebuild rather than restoring a poisoned snapshot.

## Unblocks

PR #137 (chore: remove EventImpact forecasting) — its `ios-build` failure is the same cache-collision symptom. After this lands I'll rebase #137 on main.

## Side note (not addressed here)

PR #120 silently reverted PR #135's RN 0.85.2 bump + `@react-native/jest-preset` migration. Mobile is currently consistent at RN 0.82.1, so it's not breaking anything, but we should decide whether to re-bump or formally accept the revert. Tracking separately.