### PR TITLE
fix(backend): drop orphan notification_logs + push_tokens tables

### DIFF
--- a/apps/backend/prisma/migrations/20260501085200_drop_orphan_push_notification_tables/migration.sql
+++ b/apps/backend/prisma/migrations/20260501085200_drop_orphan_push_notification_tables/migration.sql
@@ -1,0 +1,22 @@
+-- Drop orphan tables `notification_logs` and `push_tokens`.
+--
+-- Background: production has a `_prisma_migrations` row for `20260501010714_add_push_notifications`
+-- that was applied directly against the prod database but whose migration folder was never committed
+-- to git. The two tables it created (`notification_logs`, `push_tokens`) are empty in prod and have no
+-- references anywhere in the codebase. Zach's incoming notifications PR will recreate them through the
+-- normal Prisma flow with a properly-modeled schema, so we drop them here and remove the orphan
+-- `_prisma_migrations` row to bring prod back in sync with `main`.
+--
+-- All statements are idempotent (`IF EXISTS`) so this migration is safe to apply against any database
+-- (prod, branch dbs, fresh local installs created from `schema.prisma` without the orphan migration).
+
+-- DropForeignKey
+ALTER TABLE IF EXISTS "notification_logs" DROP CONSTRAINT IF EXISTS "notification_logs_user_id_fkey";
+ALTER TABLE IF EXISTS "push_tokens" DROP CONSTRAINT IF EXISTS "push_tokens_user_id_fkey";
+
+-- DropTable
+DROP TABLE IF EXISTS "notification_logs";
+DROP TABLE IF EXISTS "push_tokens";
+
+-- Remove the orphan migration record so `prisma migrate status` reports a clean state.
+DELETE FROM "_prisma_migrations" WHERE migration_name = '20260501010714_add_push_notifications';


### PR DESCRIPTION
## Why

Production has a `_prisma_migrations` row for `20260501010714_add_push_notifications` whose migration folder was **never committed to git**. The two tables it created (`notification_logs`, `push_tokens`) are empty in prod (0 rows each) and unreferenced anywhere in the codebase.

Left as-is this blocks Zach's incoming notifications PR — his `prisma migrate dev` run would collide with tables that already exist in prod but aren't in the schema.

## What

A single SQL migration that:

1. Drops both orphan tables (idempotent `DROP TABLE IF EXISTS` so it's safe on every environment, including fresh local installs that never had the orphan).
2. Drops the matching foreign-key constraints first (also `IF EXISTS`).
3. Removes the orphan `_prisma_migrations` row so `prisma migrate status` reports a clean state and future deploys don't carry a phantom migration record.

No `schema.prisma` changes — neither table was ever modeled there. Zach's notifications PR will introduce both models the proper way.

## Verification

- Created a Neon branch from prod (`drift-fix-test`), ran the migration's statements as a transaction. After:
  - `to_regclass('public.notification_logs')` → `null`
  - `to_regclass('public.push_tokens')` → `null`
  - `select count(*) from _prisma_migrations where migration_name = '20260501010714_add_push_notifications'` → `0`
- Branch deleted afterwards.
- `pnpm prisma validate` passes.
- Husky pre-commit hook (lint + typecheck) passed.

## Deploy notes

Standard `prisma migrate deploy` on the next merge-to-main deploy. No app restart or special ordering needed; both tables are unused.

## Follow-up

Unblocks Zach's notifications PR — he should land `PushToken` + `NotificationLog` Prisma models with whatever final shape his sender service needs.
