### PR TITLE
feat(mobile): wire ReportModal.onSubmit to POST /reports

### DIFF
--- a/apps/mobile/__tests__/LotAmenities.test.tsx
+++ b/apps/mobile/__tests__/LotAmenities.test.tsx
@@ -37,6 +37,7 @@ import { collectTexts } from './testUtils';
 // ────────────────────── Helpers ──────────────────────
 
 const makeLot = (overrides: Partial<ParkingLotResponse> = {}): ParkingLotResponse => ({
+  id: 'cltest000000000001',
   lot_id: 'G1',
   lot_name: 'Lot G1',
   display_name: 'Lot G1',

--- a/apps/mobile/__tests__/RealGeofencingIntegration.simple.test.ts
+++ b/apps/mobile/__tests__/RealGeofencingIntegration.simple.test.ts
@@ -16,6 +16,7 @@ describe('Real Geofencing Integration (Simple)', () => {
   // Sample minimal parking lot data
   const mockRealLots: ParkingLotResponse[] = [
     {
+      id: 'cltest000000000001',
       lot_id: 'G1',
       lot_name: 'G1 Student Parking',
       display_name: 'G1 Parking Lot',
@@ -63,6 +64,7 @@ describe('Real Geofencing Integration (Simple)', () => {
       timestamp: '2024-01-01T00:00:00Z',
     },
     {
+      id: 'cltest000000000002',
       lot_id: 'G2',
       lot_name: 'G2 Student Parking',
       display_name: 'G2 Parking Lot',

--- a/apps/mobile/__tests__/RecommendationModal.test.tsx
+++ b/apps/mobile/__tests__/RecommendationModal.test.tsx
@@ -84,6 +84,7 @@ const findPressableAncestor = (node: ReactTestRenderer.ReactTestInstance) => {
 
 /** Minimal ParkingLotResponse fixture */
 const makeLot = (overrides: Partial<ParkingLotResponse> = {}): ParkingLotResponse => ({
+  id: 'cltest000000000001',
   lot_id: 'G1',
   lot_name: 'Lot G1',
   display_name: 'Lot G1',

--- a/apps/mobile/__tests__/ReportModal.test.tsx
+++ b/apps/mobile/__tests__/ReportModal.test.tsx
@@ -36,7 +36,7 @@ jest.mock('../src/components/CustomTextInput', () => ({
 // ────────────────────── Helpers ──────────────────────
 
 const defaultProps = {
-  lotId: 'G6',
+  lotDisplayName: 'G6',
   isOpen: true,
   onClose: jest.fn(),
   onSubmit: jest.fn().mockResolvedValue(undefined),
@@ -287,7 +287,6 @@ describe('ReportModal -- onSubmit wiring', () => {
     expect(onSubmit).toHaveBeenCalledTimes(1);
     const call = onSubmit.mock.calls[0][0];
     expect(call.type).toBe('blockage');
-    expect(call.lotId).toBe('G6');
     expect(call.timestamp).toBeInstanceOf(Date);
   });
 
@@ -341,5 +340,34 @@ describe('ReportModal -- onSubmit wiring', () => {
     expect(errorView).toBeTruthy();
     const texts = collectTexts(errorView);
     expect(hasText(texts, 'Rate limit exceeded')).toBe(true);
+  });
+
+  it('submit button is disabled while submission is in-flight', async () => {
+    // onSubmit never resolves during this test — simulates a slow network
+    const onSubmit = jest.fn().mockReturnValue(new Promise(() => {}));
+    const tree = render({ ...defaultProps, onSubmit });
+
+    const crashRadio = tree.root.find(
+      node =>
+        node.props.accessibilityRole === 'radio' &&
+        node.props.accessibilityLabel?.includes('Crash'),
+    );
+    await ReactTestRenderer.act(async () => {
+      crashRadio.props.onPress();
+    });
+
+    const submitBtn = tree.root.find(
+      node => node.props.accessibilityLabel === 'Submit report',
+    );
+    // Kick off submit but don't await — leave it in-flight
+    ReactTestRenderer.act(() => {
+      submitBtn.props.onPress();
+    });
+
+    const submitBtnDuring = tree.root.find(
+      node => node.props.accessibilityLabel === 'Submit report',
+    );
+    expect(submitBtnDuring.props.accessibilityState).toMatchObject({ disabled: true });
+    expect(submitBtnDuring.props.disabled).toBe(true);
   });
 });

--- a/apps/mobile/__tests__/ReportModal.test.tsx
+++ b/apps/mobile/__tests__/ReportModal.test.tsx
@@ -39,7 +39,7 @@ const defaultProps = {
   lotId: 'G6',
   isOpen: true,
   onClose: jest.fn(),
-  onSubmit: jest.fn(),
+  onSubmit: jest.fn().mockResolvedValue(undefined),
 };
 
 function render(props = defaultProps) {
@@ -254,5 +254,92 @@ describe('ReportModal -- submit button accessibility', () => {
       node => node.props.accessibilityLabel === 'Additional details',
     );
     expect(input.props.accessibilityHint).toBe('Describe the incident');
+  });
+});
+
+describe('ReportModal -- onSubmit wiring', () => {
+  beforeEach(() => {
+    defaultProps.onSubmit.mockResolvedValue(undefined);
+    defaultProps.onClose.mockClear();
+  });
+
+  it('calls onSubmit with correct payload on blockage submit', async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    const onClose = jest.fn();
+    const tree = render({ ...defaultProps, onSubmit, onClose });
+
+    const blockageRadio = tree.root.find(
+      node =>
+        node.props.accessibilityRole === 'radio' &&
+        node.props.accessibilityLabel?.includes('Blockage'),
+    );
+    await ReactTestRenderer.act(async () => {
+      blockageRadio.props.onPress();
+    });
+
+    const submitBtn = tree.root.find(
+      node => node.props.accessibilityLabel === 'Submit report',
+    );
+    await ReactTestRenderer.act(async () => {
+      submitBtn.props.onPress();
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const call = onSubmit.mock.calls[0][0];
+    expect(call.type).toBe('blockage');
+    expect(call.lotId).toBe('G6');
+    expect(call.timestamp).toBeInstanceOf(Date);
+  });
+
+  it('closes the modal after a successful submit', async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    const onClose = jest.fn();
+    const tree = render({ ...defaultProps, onSubmit, onClose });
+
+    const crashRadio = tree.root.find(
+      node =>
+        node.props.accessibilityRole === 'radio' &&
+        node.props.accessibilityLabel?.includes('Crash'),
+    );
+    await ReactTestRenderer.act(async () => {
+      crashRadio.props.onPress();
+    });
+
+    const submitBtn = tree.root.find(
+      node => node.props.accessibilityLabel === 'Submit report',
+    );
+    await ReactTestRenderer.act(async () => {
+      submitBtn.props.onPress();
+    });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows error banner when onSubmit rejects', async () => {
+    const onSubmit = jest.fn().mockRejectedValue(new Error('Rate limit exceeded'));
+    const tree = render({ ...defaultProps, onSubmit });
+
+    const crashRadio = tree.root.find(
+      node =>
+        node.props.accessibilityRole === 'radio' &&
+        node.props.accessibilityLabel?.includes('Crash'),
+    );
+    await ReactTestRenderer.act(async () => {
+      crashRadio.props.onPress();
+    });
+
+    const submitBtn = tree.root.find(
+      node => node.props.accessibilityLabel === 'Submit report',
+    );
+    await ReactTestRenderer.act(async () => {
+      submitBtn.props.onPress();
+    });
+
+    const errorView = tree.root.find(
+      node => node.props.accessibilityRole === 'alert',
+    );
+    expect(errorView).toBeTruthy();
+    const texts = collectTexts(errorView);
+    expect(hasText(texts, 'Rate limit exceeded')).toBe(true);
   });
 });

--- a/apps/mobile/src/components/Modals/ReportModal.tsx
+++ b/apps/mobile/src/components/Modals/ReportModal.tsx
@@ -3,6 +3,7 @@ import {
   View, Modal,
   TouchableOpacity,
   ScrollView, StyleSheet,
+  ActivityIndicator,
 } from 'react-native';
 import { Text } from '../CustomText';
 import { TextInput } from '../CustomTextInput';
@@ -13,7 +14,7 @@ interface ReportModalProps {
   lotId: string;
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (report: IncidentReport) => void;
+  onSubmit: (report: IncidentReport) => Promise<void>;
 }
 
 export interface IncidentReport {
@@ -26,28 +27,41 @@ export interface IncidentReport {
 export function ReportModal({ lotId, isOpen, onClose, onSubmit }: ReportModalProps) {
   const [selectedType, setSelectedType] = useState<'blockage' | 'crash' | 'other' | null>(null);
   const [message, setMessage] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const { colors } = useTheme();
 
   const styles = useMemo(() => getStyles(colors), [colors]);
 
   const handleClose = () => {
+    if (isSubmitting) return;
     setSelectedType(null);
     setMessage('');
+    setSubmitError(null);
     onClose();
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!selectedType) return;
     if (selectedType === 'other' && !message.trim()) return;
+    if (isSubmitting) return;
 
-    onSubmit({
-      lotId,
-      type: selectedType,
-      message,
-      timestamp: new Date(),
-    });
-
-    handleClose();
+    setIsSubmitting(true);
+    setSubmitError(null);
+    try {
+      await onSubmit({
+        lotId,
+        type: selectedType,
+        message,
+        timestamp: new Date(),
+      });
+      handleClose();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Something went wrong. Please try again.';
+      setSubmitError(msg);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const incidentTypes = [
@@ -169,20 +183,32 @@ export function ReportModal({ lotId, isOpen, onClose, onSubmit }: ReportModalPro
               </View>
             )}
 
+            {/* Error banner */}
+            {submitError && (
+              <View style={styles.errorBanner} accessibilityRole="alert">
+                <Text style={styles.errorText}>{submitError}</Text>
+              </View>
+            )}
+
             {/* Submit Button */}
-            <TouchableOpacity
-              onPress={handleSubmit}
-              disabled={!selectedType || (selectedType === 'other' && !message.trim())}
-              style={[
-                styles.submitButton,
-                (!selectedType || (selectedType === 'other' && !message.trim())) && styles.submitButtonDisabled
-              ]}
-              accessibilityRole="button"
-              accessibilityLabel="Submit report"
-              accessibilityState={{ disabled: !selectedType || (selectedType === 'other' && !message.trim()) }}
-            >
-              <Text style={styles.submitButtonText}>Submit Report</Text>
-            </TouchableOpacity>
+            {(() => {
+              const isDisabled = !selectedType || (selectedType === 'other' && !message.trim()) || isSubmitting;
+              return (
+                <TouchableOpacity
+                  onPress={handleSubmit}
+                  disabled={isDisabled}
+                  style={[styles.submitButton, isDisabled && styles.submitButtonDisabled]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Submit report"
+                  accessibilityState={{ disabled: isDisabled }}
+                >
+                  {isSubmitting
+                    ? <ActivityIndicator color={colors.white} />
+                    : <Text style={styles.submitButtonText}>Submit Report</Text>
+                  }
+                </TouchableOpacity>
+              );
+            })()}
           </ScrollView>
         </View>
       </View>
@@ -361,5 +387,16 @@ const getStyles = (
     color: colors.white,
     fontSize: 16,
     fontFamily: TYPOGRAPHY.fontFamily.semibold,
+  },
+  errorBanner: {
+    backgroundColor: colors.errorLight,
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 12,
+  },
+  errorText: {
+    color: colors.error,
+    fontSize: 14,
+    fontFamily: TYPOGRAPHY.fontFamily.regular,
   },
 });

--- a/apps/mobile/src/components/Modals/ReportModal.tsx
+++ b/apps/mobile/src/components/Modals/ReportModal.tsx
@@ -9,22 +9,23 @@ import { Text } from '../CustomText';
 import { TextInput } from '../CustomTextInput';
 import { useTheme, ThemeColors } from '../../context/ThemeContext';
 import { TYPOGRAPHY } from '../../constants/theme';
+import type { ReportType } from '../../services/api/reports';
 
 interface ReportModalProps {
-  lotId: string;
+  /** Human-readable lot display name shown in the modal subtitle (e.g. "G2"). */
+  lotDisplayName: string;
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (report: IncidentReport) => Promise<void>;
 }
 
 export interface IncidentReport {
-  lotId: string;
-  type: 'blockage' | 'crash' | 'other';
+  type: ReportType;
   message: string;
   timestamp: Date;
 }
 
-export function ReportModal({ lotId, isOpen, onClose, onSubmit }: ReportModalProps) {
+export function ReportModal({ lotDisplayName, isOpen, onClose, onSubmit }: ReportModalProps) {
   const [selectedType, setSelectedType] = useState<'blockage' | 'crash' | 'other' | null>(null);
   const [message, setMessage] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -50,7 +51,6 @@ export function ReportModal({ lotId, isOpen, onClose, onSubmit }: ReportModalPro
     setSubmitError(null);
     try {
       await onSubmit({
-        lotId,
         type: selectedType,
         message,
         timestamp: new Date(),
@@ -88,6 +88,8 @@ export function ReportModal({ lotId, isOpen, onClose, onSubmit }: ReportModalPro
     },
   ];
 
+  const isDisabled = !selectedType || (selectedType === 'other' && !message.trim()) || isSubmitting;
+
   return (
     <Modal
       visible={isOpen}
@@ -106,7 +108,7 @@ export function ReportModal({ lotId, isOpen, onClose, onSubmit }: ReportModalPro
           <View style={styles.header}>
             <View>
               <Text style={styles.title}>Report Incident</Text>
-              <Text style={styles.subtitle}>Parking Lot {lotId}</Text>
+              <Text style={styles.subtitle}>Parking Lot {lotDisplayName}</Text>
             </View>
             <TouchableOpacity
               onPress={handleClose}
@@ -191,24 +193,19 @@ export function ReportModal({ lotId, isOpen, onClose, onSubmit }: ReportModalPro
             )}
 
             {/* Submit Button */}
-            {(() => {
-              const isDisabled = !selectedType || (selectedType === 'other' && !message.trim()) || isSubmitting;
-              return (
-                <TouchableOpacity
-                  onPress={handleSubmit}
-                  disabled={isDisabled}
-                  style={[styles.submitButton, isDisabled && styles.submitButtonDisabled]}
-                  accessibilityRole="button"
-                  accessibilityLabel="Submit report"
-                  accessibilityState={{ disabled: isDisabled }}
-                >
-                  {isSubmitting
-                    ? <ActivityIndicator color={colors.white} />
-                    : <Text style={styles.submitButtonText}>Submit Report</Text>
-                  }
-                </TouchableOpacity>
-              );
-            })()}
+            <TouchableOpacity
+              onPress={handleSubmit}
+              disabled={isDisabled}
+              style={[styles.submitButton, isDisabled && styles.submitButtonDisabled]}
+              accessibilityRole="button"
+              accessibilityLabel="Submit report"
+              accessibilityState={{ disabled: isDisabled }}
+            >
+              {isSubmitting
+                ? <ActivityIndicator color={colors.white} />
+                : <Text style={styles.submitButtonText}>Submit Report</Text>
+              }
+            </TouchableOpacity>
           </ScrollView>
         </View>
       </View>

--- a/apps/mobile/src/screens/ShortTermForecastScreen.tsx
+++ b/apps/mobile/src/screens/ShortTermForecastScreen.tsx
@@ -401,7 +401,7 @@ export function ShortTermForecastScreen() {
 
       {/* Incident Report Modal */}
       <ReportModal
-        lotId={lot.lot_id}
+        lotDisplayName={lot.lot_id}
         isOpen={isReportModalOpen}
         onClose={() => setIsReportModalOpen(false)}
         onSubmit={handleReportSubmit}

--- a/apps/mobile/src/screens/ShortTermForecastScreen.tsx
+++ b/apps/mobile/src/screens/ShortTermForecastScreen.tsx
@@ -28,6 +28,7 @@ import { EventBanner } from '../components/EventBanner';
 import { upcomingEvents } from '../data/mockEvents';
 import { ReportModal } from '../components/Modals/ReportModal';
 import { ReliabilityModal } from '../components/Modals/ReliabilityModal';
+import { reportsApi, ReportUnauthorizedError, ReportThrottledError } from '../services/api/reports';
 import type { MapStackScreenProps } from '../types/navigation';
 
 // Format a wall-clock timestamp into a short "X ago" relative string for the
@@ -93,6 +94,32 @@ export function ShortTermForecastScreen() {
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
   const [isReliabilityModalOpen, setIsReliabilityModalOpen] = useState(false);
   const [isMapModalOpen, setIsMapModalOpen] = useState(false);
+
+  const handleReportSubmit = async (report: import('../components/Modals/ReportModal').IncidentReport) => {
+    if (isGuest || !isAuthenticated) {
+      setIsReportModalOpen(false);
+      navigation.navigate('Profile' as never);
+      return;
+    }
+    if (!lot?.id) throw new Error('Lot data unavailable. Please try again.');
+    try {
+      await reportsApi.create({
+        lotId: lot.id,
+        type: report.type,
+        message: report.message || undefined,
+      });
+    } catch (err) {
+      if (err instanceof ReportUnauthorizedError) {
+        setIsReportModalOpen(false);
+        navigation.navigate('Profile' as never);
+        return;
+      }
+      if (err instanceof ReportThrottledError) {
+        throw err; // ReportModal will surface the message
+      }
+      throw err;
+    }
+  };
 
   // For favorites
   const { addFavorite, removeFavorite, favoriteLots } = useFavorites();
@@ -377,7 +404,7 @@ export function ShortTermForecastScreen() {
         lotId={lot.lot_id}
         isOpen={isReportModalOpen}
         onClose={() => setIsReportModalOpen(false)}
-        onSubmit={() => {}} // currently do nothing on submit
+        onSubmit={handleReportSubmit}
       />
 
       {/* Reliability Details Modal */}

--- a/apps/mobile/src/services/api/index.ts
+++ b/apps/mobile/src/services/api/index.ts
@@ -22,6 +22,10 @@ export type {
   LotRecommendation,
 } from './lots';
 
+// Reports service
+export { reportsApi, ReportUnauthorizedError, ReportThrottledError } from './reports';
+export type { CreateReportPayload, CreateReportResponse, ReportType } from './reports';
+
 // Import for default export
 import API_CONFIG from './config';
 import { apiService } from './base';

--- a/apps/mobile/src/services/api/lots.ts
+++ b/apps/mobile/src/services/api/lots.ts
@@ -43,6 +43,8 @@ function redactLotIfRevoked<T extends ParkingLotResponse>(lot: T): T {
 
 // Backend response interfaces (matching the backend)
 export interface ParkingLot {
+  /** Prisma cuid — used as lotId when POSTing to /reports */
+  id: string;
   lot_id: string;
   lot_name: string;
   display_name: string;

--- a/apps/mobile/src/services/api/reports.ts
+++ b/apps/mobile/src/services/api/reports.ts
@@ -1,0 +1,60 @@
+/**
+ * Reports API Service
+ * POST /reports — submit an incident report for a parking lot.
+ *
+ * Payload: { lotId: string (cuid), type: 'blockage'|'crash'|'other', message?: string }
+ * Response: { id: string, created_at: string }
+ * Throttled: 5 requests / minute / user
+ * Auth: 401 for unauthenticated / guest callers
+ */
+import { apiService, ApiError } from './base';
+
+export type ReportType = 'blockage' | 'crash' | 'other';
+
+export interface CreateReportPayload {
+  /** Lot.id (cuid) — NOT the human-readable lot_id like 'G2' */
+  lotId: string;
+  type: ReportType;
+  message?: string;
+}
+
+export interface CreateReportResponse {
+  id: string;
+  created_at: string;
+}
+
+/** Thrown when a guest or unauthenticated user hits POST /reports. */
+export class ReportUnauthorizedError extends ApiError {
+  constructor() {
+    super(401, 'You must be signed in to submit a report');
+    this.name = 'ReportUnauthorizedError';
+  }
+}
+
+/** Thrown when the user exceeds the 5/min throttle limit. */
+export class ReportThrottledError extends ApiError {
+  constructor() {
+    super(429, 'You\'re submitting reports too quickly. Please wait a moment.');
+    this.name = 'ReportThrottledError';
+  }
+}
+
+const reportsApi = {
+  async create(payload: CreateReportPayload): Promise<CreateReportResponse> {
+    try {
+      const response = await apiService.post<CreateReportResponse>(
+        '/reports',
+        payload,
+      );
+      return response.data ?? (response as unknown as CreateReportResponse);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        if (error.status === 401) throw new ReportUnauthorizedError();
+        if (error.status === 429) throw new ReportThrottledError();
+      }
+      throw error;
+    }
+  },
+};
+
+export { reportsApi };

--- a/apps/mobile/src/services/api/reports.ts
+++ b/apps/mobile/src/services/api/reports.ts
@@ -46,6 +46,10 @@ const reportsApi = {
         '/reports',
         payload,
       );
+      // apiService.post<T> is typed as returning { success, data: T }, but
+      // ReportsController returns the object raw (not wrapped). The fallback
+      // cast is load-bearing — don't remove it without aligning the backend
+      // response shape or the base apiService generic.
       return response.data ?? (response as unknown as CreateReportResponse);
     } catch (error) {
       if (error instanceof ApiError) {


### PR DESCRIPTION
## Summary
Wires `ReportModal.onSubmit` to the live `POST /reports` endpoint (unblocked by PR #121). Previously the submit handler was a no-op (`() => {}`); reports now POST to the backend and surface loading/error state to the user.

## Changes

### New: `src/services/api/reports.ts`
- `reportsApi.create({ lotId, type, message? })` — POSTs to `/reports`
- `ReportUnauthorizedError` — thrown on 401 (guest / unauthenticated)
- `ReportThrottledError` — thrown on 429 (5/min limit exceeded)
- Both exported from `src/services/api/index.ts`

### `src/services/api/lots.ts`
- Added `id: string` (cuid) to `ParkingLot` interface — the backend already returns it via `...meta` spread in `transformToResponse`; we just weren't declaring it on the mobile type

### `src/components/Modals/ReportModal.tsx`
- `onSubmit` signature: `() => void` → `(report: IncidentReport) => Promise<void>`
- Added `isSubmitting` state — disables submit button and shows `ActivityIndicator` while the request is in flight
- Added `submitError` state — renders an inline error banner (`accessibilityRole="alert"`) on rejection; clears on close
- `handleClose` is a no-op while submitting (prevents closing mid-request)

### `src/screens/ShortTermForecastScreen.tsx`
- `handleReportSubmit` — replaces the `() => {}` stub
  - Guards: guests and unauthenticated users are redirected to the Profile tab (same pattern as the favorites gate)
  - Uses `lot.id` (cuid) as `lotId`, **not** `lot.lot_id` (`'G2'`-style code) — matches the DTO
  - Re-throws `ReportThrottledError` so `ReportModal` surfaces the message; 401 short-circuits to navigation

## Behaviour

| Scenario | Result |
|---|---|
| Authenticated user submits | POST fires, modal closes on success |
| Guest taps Submit | Modal closes, navigates to Profile tab |
| Rate limit hit (5/min) | Inline error banner: *"You're submitting reports too quickly…"* |
| Network / server error | Inline error banner with error message |
| Submit in flight | Button disabled + spinner, backdrop close blocked |

## Testing
- 3 new `ReportModal` tests: correct payload on submit, closes on success, error banner on rejection
- `onSubmit` mock updated to `mockResolvedValue(undefined)` across existing tests
- Test fixtures in `LotAmenities`, `RecommendationModal`, `RealGeofencingIntegration` updated with required `id` field
- **609/609 tests pass** — lint typecheck 