### PR TITLE
chore(mobile): rename bundle ID com.sharkpark.mobile → app.sharkpark.mobile

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -85,7 +85,7 @@ android {
 
     namespace "com.mobile"
     defaultConfig {
-        applicationId "com.sharkpark.mobile"
+        applicationId "app.sharkpark.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 2

--- a/apps/mobile/docs/apple-app-site-association.json
+++ b/apps/mobile/docs/apple-app-site-association.json
@@ -3,7 +3,7 @@
     "apps": [],
     "details": [
       {
-        "appID": "TEAMID.com.sharkpark.mobile",
+        "appID": "4K793ZW77F.app.sharkpark.mobile",
         "paths": [
           "/map",
           "/map/lot/*",

--- a/apps/mobile/ios/mobile.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/mobile.xcodeproj/project.pbxproj
@@ -309,7 +309,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.sharkpark.mobile;
+				PRODUCT_BUNDLE_IDENTIFIER = app.sharkpark.mobile;
 				PRODUCT_NAME = mobile;
 				SWIFT_OBJC_BRIDGING_HEADER = "mobile/mobile-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -340,7 +340,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.sharkpark.mobile;
+				PRODUCT_BUNDLE_IDENTIFIER = app.sharkpark.mobile;
 				PRODUCT_NAME = mobile;
 				SWIFT_OBJC_BRIDGING_HEADER = "mobile/mobile-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/apps/mobile/ios/mobile/Info.plist
+++ b/apps/mobile/ios/mobile/Info.plist
@@ -27,12 +27,12 @@
 		<dict>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>msauth.com.sharkpark.mobile</string>
+				<string>msauth.app.sharkpark.mobile</string>
 			</array>
 		</dict>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>com.sharkpark.mobile</string>
+			<string>app.sharkpark.mobile</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>sharkpark</string>

--- a/apps/mobile/src/auth/AzureAuth.tsx
+++ b/apps/mobile/src/auth/AzureAuth.tsx
@@ -15,8 +15,8 @@ const AZURE_CONFIG = {
 
 // Platform-specific redirect URIs (trailing slash required for proper callback handling)
 const REDIRECT_URL = Platform.select({
-  ios: 'msauth.com.sharkpark.mobile://auth/',
-  android: 'msauth://com.sharkpark.mobile/pCBsiXaNNNC6c0uvCpHWkdYi2Mk%3D',
+  ios: 'msauth.app.sharkpark.mobile://auth/',
+  android: 'msauth://app.sharkpark.mobile/pCBsiXaNNNC6c0uvCpHWkdYi2Mk%3D',
 }) as string;
 
 // Token refresh buffer (5 minutes before expiration)


### PR DESCRIPTION
## Why

`com.sharkpark.mobile` was unavailable in Apple's global App ID namespace (someone else had registered it). New ID `app.sharkpark.mobile` is the reverse-DNS of our owned domain `sharkpark.app` and works for both iOS + Android with a single identifier.

## What changed

- **iOS**: `project.pbxproj` Debug + Release `PRODUCT_BUNDLE_IDENTIFIER`, `Info.plist` MSAL URL scheme + bundle URL name
- **Android**: `build.gradle` `applicationId`
- **Mobile auth**: `AzureAuth.tsx` MSAL redirect URIs (iOS + Android)
- **AASA manifest** (`apps/mobile/docs/`): updated `appID`; also filled in real Apple Team ID `4K793ZW77F` (was `TEAMID` placeholder)

## Out-of-band changes already done

- ✅ Apple App ID registered as `app.sharkpark.mobile` (Associated Domains + Push Notifications capabilities)
- ✅ Azure AD app registration (CSULB tenant, client `9aea0ab1-4502-4868-a31b-0a8f333cec9c`) — added new `app.*` redirect URIs, removed old `com.*` URIs
- ✅ `pod install` regenerated iOS xcconfigs locally
- ✅ App Store Connect listing created with name `SharkPark – CSULB Parking` (the unqualified `SharkPark` name was already taken on App Store Connect)

## Out of scope (lands separately)

- `apps/marketing/public/.well-known/apple-app-site-association` + `assetlinks.json` — bundled with the marketing scaffold PR (still untracked locally)

## Test plan

- ✅ Pre-commit `turbo typecheck` passed across all 5 workspaces
- ⏳ Will verify on next clean iOS dev build that MSAL sign-in completes against the new redirect URI
- ⏳ Will verify on next Android dev build that `assetlinks.json` (once hosted) plus the new `applicationId` autoVerifies the universal link intent filter