### PR TITLE
fix(ci): wrangler-action fails in pnpm workspace

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -48,4 +48,10 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy apps/marketing/dist --project-name=sharkpark-marketing --branch=main
+          # Run from the marketing workspace so wrangler-action finds the
+          # locally-installed `wrangler` devDep (in apps/marketing/package.json)
+          # instead of trying to install it at the monorepo root, where pnpm
+          # rejects implicit root installs (-w required).
+          workingDirectory: apps/marketing
+          packageManager: pnpm
+          command: pages deploy dist --project-name=sharkpark-marketing --branch=main


### PR DESCRIPTION
## Problem

The `Deploy marketing site` workflow fails on first run after the rebrand merge:

```
Run cloudflare/wrangler-action@v3
🔍 Checking for existing Wrangler installation
📥 Installing Wrangler
Error: The process '/home/runner/setup-pnpm/node_modules/.bin/pnpm' failed with exit code 1
Error: 🚨 Action failed
```

`cloudflare/wrangler-action@v3` runs from the repo root by default and tries to `pnpm add wrangler` there, but pnpm rejects implicit root installs in a workspace (requires `-w`).

## Fix

- `workingDirectory: apps/marketing` → action runs from the marketing workspace, where `wrangler` is already a `devDependency`, so the install step short-circuits.
- `packageManager: pnpm` → explicit, no npm/yarn fallback.
- Updated `command:` from `pages deploy apps/marketing/dist` → `pages deploy dist` (now relative to `workingDirectory`).

## Verification

After this merges, the next push to `main` that touches `apps/marketing/**` will trigger the deploy. Can also test via Actions → Deploy marketing site → Run workflow.