### PR TITLE
fix(ci): invoke wrangler directly for deterministic version + real errors

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -44,14 +44,16 @@ jobs:
         run: pnpm --filter @sharkpark/marketing build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # Run from the marketing workspace so wrangler-action finds the
-          # locally-installed `wrangler` devDep (in apps/marketing/package.json)
-          # instead of trying to install it at the monorepo root, where pnpm
-          # rejects implicit root installs (-w required).
-          workingDirectory: apps/marketing
-          packageManager: pnpm
-          command: pages deploy dist --project-name=sharkpark-marketing --branch=main
+        # Invoke wrangler directly (rather than via cloudflare/wrangler-action)
+        # so we get:
+        #   1. The exact version pinned in apps/marketing/package.json +
+        #      pnpm-lock.yaml (currently 4.87.0). The action ships its own
+        #      bundled wrangler (v3.90 default) that drifts from local dev.
+        #   2. Real stderr — the action wraps wrangler in a subprocess and
+        #      surfaces only "exit code 1" with no underlying message.
+        #   3. One less third-party action in the supply chain.
+        working-directory: apps/marketing
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm exec wrangler pages deploy dist --project-name=sharkpark-marketing --branch=main


### PR DESCRIPTION
## Why

PR #166 wired `cloudflare/wrangler-action@v3` into the marketing workflow, but it still failed with a bare `Error: process exited with code 1` and no underlying message. Two root causes hidden behind that line:

1. **Version drift** — the action shipped its own bundled wrangler **3.90.0** and ignored our local `wrangler@^4.87.0` devDep. Wrangler v3 vs v4 have different command signatures and output formats.
2. **Swallowed stderr** — the action wraps wrangler in a subprocess and surfaces only the exit code; the actual error never makes it to the Actions log.

## What

Replace the action with a direct `pnpm exec wrangler pages deploy` call from `apps/marketing`.

- Uses the exact version pinned in `pnpm-lock.yaml` (4.87.0) — same as local dev.
- Real wrangler stderr now flows to the Actions log.
- One fewer third-party action in the supply chain.

## Test

Merge → workflow runs → either deploy succeeds, or we finally see the actual wrangler error and fix it.