### PR TITLE
fix(ci): bump deploy-marketing to Node 22 (wrangler 4.x requirement)

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # Wrangler 4.x requires Node >= 22. Matches all other workflows.
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
Wrangler 4.x requires Node >= 22; this workflow was still on Node 20. All other workflows (ci, deploy, neon_workflow, seed-prod-lots) already use Node 22 — this one was the outlier.\n\nThis PR bumps the Node version for the marketing deploy workflow to 22, unblocking wrangler 4.x deploys.