### PR TITLE
fix(ci): deploy marketing as Workers project (not Pages)

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -1,4 +1,4 @@
-name: Deploy marketing site
+name: Deploy marketing site to Cloudflare Workers
 
 on:
   push:
@@ -44,17 +44,13 @@ jobs:
       - name: Build marketing site
         run: pnpm --filter @sharkpark/marketing build
 
-      - name: Deploy to Cloudflare Pages
-        # Invoke wrangler directly (rather than via cloudflare/wrangler-action)
-        # so we get:
-        #   1. The exact version pinned in apps/marketing/package.json +
-        #      pnpm-lock.yaml (currently 4.87.0). The action ships its own
-        #      bundled wrangler (v3.90 default) that drifts from local dev.
-        #   2. Real stderr — the action wraps wrangler in a subprocess and
-        #      surfaces only "exit code 1" with no underlying message.
-        #   3. One less third-party action in the supply chain.
+      - name: Deploy to Cloudflare Workers
+        # The marketing site is a Workers project with static assets
+        # (see apps/marketing/wrangler.jsonc — uses `assets.directory`,
+        # the modern Workers Static Assets pattern, NOT Cloudflare Pages).
+        # Config (name, compatibility_date, assets dir) lives in wrangler.jsonc.
         working-directory: apps/marketing
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: pnpm exec wrangler pages deploy dist --project-name=sharkpark-marketing --branch=main
+        run: pnpm exec wrangler deploy


### PR DESCRIPTION
## Why

PR #168 fixed Node version, but the deploy still failed with:

```
✘ [ERROR] Project not found. The specified project name does not match
  any of your existing projects. [code: 8000007]
```

Investigation: `sharkpark-marketing` exists in the Cloudflare account as a **Worker**, not a Pages project. The `apps/marketing/wrangler.jsonc` confirms this — it uses the modern **Workers Static Assets** pattern (`assets.directory: ./dist`, `not_found_handling: 404-page`), not Pages config.

Wrangler even warned about this on the failed run:
> Pages now has wrangler.jsonc support. We detected a configuration file at `apps/marketing/wrangler.jsonc` but it is missing the `pages_build_output_dir` field, required by Pages.

That's because the file isn't a Pages config — it's a Workers config.

## What

- Switch `pnpm exec wrangler pages deploy dist --project-name=… --branch=main` → `pnpm exec wrangler deploy`
- Workers `deploy` reads name, compatibility_date, and assets dir from `wrangler.jsonc` directly
- Renamed workflow to "Deploy marketing site to Cloudflare Workers" for clarity

## ⚠️ Required token permission change

The `CLOUDFLARE_API_TOKEN` was scoped to `Account · Cloudflare Pages · Edit`. Workers deploys require **`Account · Workers Scripts · Edit`** instead (or in addition). If the token isn't updated, the deploy will fail with a 403.

**Action required before merging:**
1. https://dash.cloudflare.com/profile/api-tokens → edit `sharkpark-pages-deploy` (or create a new one named `sharkpark-workers-deploy`)
2. Permissions: **Account · Workers Scripts · Edit** (you can drop the Pages permission)
3. Update the `CLOUDFLARE_API_TOKEN` repo secret

## Test

Merge → workflow runs → should successfully deploy to the existing `sharkpark-marketing` Worker.