### PR TITLE
fix(marketing): remove _redirects (unsupported in Workers Static Assets)

### DIFF
--- a/apps/marketing/public/_redirects
+++ b/apps/marketing/public/_redirects
@@ -1,2 +1,0 @@
-# Force apex domain — www -> sharkpark.app
-https://www.sharkpark.app/* https://sharkpark.app/:splat 301!


### PR DESCRIPTION
## Why

PR #169 successfully switched the deploy to `wrangler deploy` — token + permissions worked, asset upload worked, but the version creation failed with:

```
✘ [ERROR] Invalid _redirects configuration:
  Line 2: Only relative URLs are allowed. [code: 10021]
```

The file:

```
# Force apex domain — www -> sharkpark.app
https://www.sharkpark.app/* https://sharkpark.app/:splat 301!
```

Workers Static Assets `_redirects` only supports **relative** URLs (Pages supports absolute, but we're not on Pages). Cross-hostname redirects must live at the Cloudflare zone level.

## What

- Delete `apps/marketing/public/_redirects` (and the build-output copy will disappear on next `pnpm build`)

## ⚠️ Required dashboard config

Set up apex enforcement as a **Single Redirect Rule** at the Cloudflare zone level:

1. https://dash.cloudflare.com → `sharkpark.app` zone → **Rules** → **Redirect Rules** → **Create rule**
2. **Rule name:** `www -> apex`
3. **When incoming requests match:** Custom filter expression → `(http.host eq "www.sharkpark.app")`
4. **Then:** Type = **Dynamic** → Expression = `concat("https://sharkpark.app", http.request.uri.path)`
5. **Status code:** 301
6. **Preserve query string:** ✅
7. Save & deploy

This is the recommended pattern for apex enforcement and is independent of the deployment artifact (works regardless of Workers vs Pages vs anything else serving the apex).

## Test

After this PR merges + the redirect rule is set up:
- `https://sharkpark.app/` → site loads
- `https://www.sharkpark.app/foo?bar=1` → 301 to `https://sharkpark.app/foo?bar=1`