### PR TITLE
fix(marketing): normalize active-nav comparison (highlight not showing in prod)

### DIFF
--- a/apps/marketing/src/components/Header.astro
+++ b/apps/marketing/src/components/Header.astro
@@ -1,7 +1,11 @@
 ---
 import { SITE, NAV_LINKS } from '../consts';
 
-const pathname = Astro.url.pathname.replace(/\/$/, '') || '/';
+const normalize = (p: string) => {
+  const stripped = p.replace(/\/+$/, '');
+  return stripped === '' ? '/' : stripped;
+};
+const pathname = normalize(Astro.url.pathname);
 ---
 <header class="sticky top-0 z-50 w-full border-b border-[var(--color-border)] bg-white/85 backdrop-blur">
   <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
@@ -12,7 +16,7 @@ const pathname = Astro.url.pathname.replace(/\/$/, '') || '/';
     <nav aria-label="Primary">
       <ul class="flex items-center gap-6 text-sm font-medium text-[var(--color-ink-soft)]">
         {NAV_LINKS.map((l) => {
-          const isCurrent = pathname === l.href;
+          const isCurrent = pathname === normalize(l.href);
           return (
             <li>
               <a


### PR DESCRIPTION
## Why

The active-nav highlight (underline + brand-700 text color) worked in local dev but didn't apply on the deployed Workers Static Assets build.

Root cause: only one side of the equality check was trailing-slash normalized. `Astro.url.pathname` can render with a trailing slash on the served HTML (depending on build format / runtime URL handling) while `NAV_LINKS` hrefs never have one, so the equality silently failed in production.

## What

Normalize **both** sides via a single helper so any trailing-slash drift between build/runtime is invisible to the check.

```diff
- const pathname = Astro.url.pathname.replace(/\/$/, '') || '/';
+ const normalize = (p: string) => {
+   const stripped = p.replace(/\/+$/, '');
+   return stripped === '' ? '/' : stripped;
+ };
+ const pathname = normalize(Astro.url.pathname);

- const isCurrent = pathname === l.href;
+ const isCurrent = pathname === normalize(l.href);
```

## Test

After deploy: navigate to `/support`, `/privacy`, `/terms` — the active link should be underlined and use `var(--color-brand-700)`.