### PR TITLE
fix(marketing): strip .html from build-time pathname + allow CF Web Analytics in CSP

### DIFF
--- a/apps/marketing/public/_headers
+++ b/apps/marketing/public/_headers
@@ -19,5 +19,6 @@
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   # Tight CSP for a static marketing site. 'unsafe-inline' is needed for the JSON-LD
   # <script type="application/ld+json"> blocks and Astro's small inline <style> tags.
-  # No third-party scripts, frames, or analytics — keep this list closed.
-  Content-Security-Policy: default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
+  # Cloudflare Web Analytics beacon (auto-injected when enabled on the zone) loads
+  # from static.cloudflareinsights.com and POSTs to cloudflareinsights.com.
+  Content-Security-Policy: default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' static.cloudflareinsights.com; font-src 'self' data:; connect-src 'self' cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests

--- a/apps/marketing/src/components/Header.astro
+++ b/apps/marketing/src/components/Header.astro
@@ -1,8 +1,15 @@
 ---
 import { SITE, NAV_LINKS } from '../consts';
 
+// Astro builds with `build.format: 'file'`, so for `src/pages/support.astro`
+// `Astro.url.pathname` is `/support.html` at build time even though the deployed
+// URL is `/support`. Strip `.html` and any trailing slash so the comparison
+// against `NAV_LINKS` hrefs (`/`, `/support`, …) is stable.
 const normalize = (p: string) => {
-  const stripped = p.replace(/\/+$/, '');
+  const stripped = p
+    .replace(/\/index\.html$/, '/')
+    .replace(/\.html$/, '')
+    .replace(/\/+$/, '');
   return stripped === '' ? '/' : stripped;
 };
 const pathname = normalize(Astro.url.pathname);


### PR DESCRIPTION
Follow-up to #171 — two issues found post-deploy.

## 1. Active-nav highlight still missing on `/support`, `/privacy`, `/terms`

Astro builds with `build.format: 'file'`, so for `src/pages/support.astro` `Astro.url.pathname` is **`/support.html`** at build time even though the deployed URL is `/support`. The previous `normalize()` only stripped trailing slashes, so the equality vs `NAV_LINKS` hrefs (`/support`) never matched.

Verified by grepping the built HTML:

```
$ grep -o 'aria-current="[^"]*"' dist/support.html
aria-current="page"
```

(empty before this change, present after.)

## 2. Cloudflare Web Analytics beacon blocked by CSP

Browser console:

```
Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/...'
violates the following Content Security Policy directive:
"script-src 'self' 'unsafe-inline'"
```

The CF Web Analytics beacon is auto-injected on the zone, so we need to allow:
- `script-src`: `static.cloudflareinsights.com`
- `connect-src`: `cloudflareinsights.com`

Everything else stays locked down.