### PR TITLE
fix(backend): cron OOM cascade, cold-start health checks, pg connect timeout, Sentry 4xx noise

### DIFF
--- a/apps/backend/fly.toml
+++ b/apps/backend/fly.toml
@@ -81,8 +81,17 @@ primary_region = 'lax'
   # node-only crons. Bumped to 1024MB on 2026-04-30 ahead of the ML
   # prediction + retraining crons (predict-all-lots.ts, retrain-models.ts)
   # which spawn Python with xgboost + pandas; those reliably need 700MB+
-  # in our local profiling and OOM-killed (exit 137) at 512MB. If we
-  # instead move retraining to an ephemeral `fly machine run` Machine,
-  # this can drop back to 512MB — pick one before retraining ships.
-  memory = '1024mb'
+  # in our local profiling and OOM-killed (exit 137) at 512MB.
+  #
+  # Bumped to 2048MB on 2026-05-03 after a production OOM cascade: at the
+  # top of the hour 5 */15 jobs (snapshot + 4 notify-* triggers) all spawn
+  # simultaneously and each loads the full AppModule (~180MB RSS — pulls in
+  # PassioGo WebSocket + Firebase Admin + every other module even though
+  # the script only needs Prisma + a couple services). 5 × 180MB > 1GB →
+  # supercronic children get OOM-killed mid-run, leaving zombie pg-pool
+  # connections and triggering "Connection terminated due to connection
+  # timeout" on survivors. The real fix is per-script lightweight Nest
+  # modules (don't bootstrap AppModule from cron); tracked as follow-up.
+  # Until then, 2GB gives ~1GB headroom for 5 concurrent bootstraps.
+  memory = '2048mb'
   processes = ['cron']

--- a/apps/backend/fly.toml
+++ b/apps/backend/fly.toml
@@ -55,7 +55,12 @@ primary_region = 'lax'
   [[http_service.checks]]
     interval = '15s'
     timeout = '2s'
-    grace_period = '10s'
+    # Cold start (min_machines_running = 0) takes ~10-15s end-to-end:
+    # Fly boot + Node + Nest module graph + Prisma connect to Neon. A 10s
+    # grace tripped Fly Doctor's "App not listening on port 3000" alert
+    # because the live probe fired before bootstrap finished. Match the
+    # ready check (30s) so cold starts don't false-alarm.
+    grace_period = '30s'
     method = 'GET'
     path = '/api/v1/health/live'
     protocol = 'http'

--- a/apps/backend/fly.toml
+++ b/apps/backend/fly.toml
@@ -88,15 +88,20 @@ primary_region = 'lax'
   # which spawn Python with xgboost + pandas; those reliably need 700MB+
   # in our local profiling and OOM-killed (exit 137) at 512MB.
   #
-  # Bumped to 2048MB on 2026-05-03 after a production OOM cascade: at the
-  # top of the hour 5 */15 jobs (snapshot + 4 notify-* triggers) all spawn
-  # simultaneously and each loads the full AppModule (~180MB RSS — pulls in
-  # PassioGo WebSocket + Firebase Admin + every other module even though
-  # the script only needs Prisma + a couple services). 5 × 180MB > 1GB →
-  # supercronic children get OOM-killed mid-run, leaving zombie pg-pool
-  # connections and triggering "Connection terminated due to connection
-  # timeout" on survivors. The real fix is per-script lightweight Nest
-  # modules (don't bootstrap AppModule from cron); tracked as follow-up.
-  # Until then, 2GB gives ~1GB headroom for 5 concurrent bootstraps.
-  memory = '2048mb'
+  # 2026-05-03 OOM cascade: at the top of the hour 5 */15 jobs (snapshot +
+  # 4 notify-* triggers) all spawn simultaneously and each used to load the
+  # full AppModule (~180MB RSS — pulled in the PassioGo WebSocket + Firebase
+  # Admin + every other module, even though the script only needs Prisma +
+  # one feature service). 5 × 180MB > 1GB → supercronic children got
+  # OOM-killed, leaving zombie pg-pool connections and triggering
+  # "Connection terminated due to connection timeout" on survivors.
+  #
+  # Fixed in PR #176 by switching cron scripts to per-script Nest modules
+  # (`CronAppModule.withFeatures([...])` in src/scripts/_cron-app.module.ts)
+  # so each bootstrap pulls in only the 1–2 feature modules it actually
+  # invokes. Each cron now lands around ~60 MB RSS, so 5 concurrent ticks
+  # comfortably fit under 500 MB and 1024MB is back to the right size for
+  # the heaviest single job (predict-all-lots / retrain-models, which spawn
+  # Python with xgboost + pandas and need ~700 MB).
+  memory = '1024mb'
   processes = ['cron']

--- a/apps/backend/src/common/filters/all-exceptions.filter.spec.ts
+++ b/apps/backend/src/common/filters/all-exceptions.filter.spec.ts
@@ -1,0 +1,142 @@
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn(),
+}));
+
+import {
+  ArgumentsHost,
+  BadRequestException,
+  ForbiddenException,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+import { AllExceptionsFilter } from './all-exceptions.filter';
+
+type MockResponse = {
+  status: jest.Mock;
+  json: jest.Mock;
+};
+
+function makeHost(
+  url = '/api/v1/lots',
+  method = 'GET',
+): { host: ArgumentsHost; res: MockResponse } {
+  const res: MockResponse = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  const req = { url, method };
+  const host = {
+    switchToHttp: () => ({
+      getResponse: () => res,
+      getRequest: () => req,
+    }),
+  } as unknown as ArgumentsHost;
+  return { host, res };
+}
+
+describe('AllExceptionsFilter', () => {
+  let filter: AllExceptionsFilter;
+
+  beforeEach(() => {
+    filter = new AllExceptionsFilter();
+    (Sentry.captureException as jest.Mock).mockClear();
+  });
+
+  it('returns the HttpException status + message in the response body', () => {
+    const { host, res } = makeHost('/api/v1/lots/missing');
+    const exc = new BadRequestException('lot id required');
+
+    filter.catch(exc, host);
+
+    expect(res.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+    const body = res.json.mock.calls[0][0];
+    expect(body).toMatchObject({
+      success: false,
+      statusCode: 400,
+      message: 'lot id required',
+      method: 'GET',
+      path: '/api/v1/lots/missing',
+    });
+    expect(typeof body.timestamp).toBe('string');
+  });
+
+  it('captures 500-class errors to Sentry', () => {
+    const { host } = makeHost();
+    const exc = new HttpException('boom', HttpStatus.INTERNAL_SERVER_ERROR);
+
+    filter.catch(exc, host);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(exc);
+  });
+
+  it('does NOT capture 4xx errors to Sentry (scanner/user-input noise)', () => {
+    const { host } = makeHost('/elanpaymentsolutions');
+    const exc = new HttpException('Not Found', HttpStatus.NOT_FOUND);
+
+    filter.catch(exc, host);
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('does not capture 401/403 to Sentry', () => {
+    const { host } = makeHost();
+    filter.catch(new HttpException('nope', HttpStatus.UNAUTHORIZED), host);
+    filter.catch(new ForbiddenException('nope'), host);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('treats unknown (non-HttpException) errors as 500 and reports to Sentry', () => {
+    const { host, res } = makeHost();
+    const exc = new Error('unexpected');
+
+    filter.catch(exc, host);
+
+    expect(res.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
+    expect(res.json.mock.calls[0][0]).toMatchObject({
+      statusCode: 500,
+      message: 'Internal server error',
+    });
+    expect(Sentry.captureException).toHaveBeenCalledWith(exc);
+  });
+
+  it('surfaces a structured `code` field from HttpException response payloads', () => {
+    const { host, res } = makeHost();
+    const exc = new ForbiddenException({
+      message: 'background location required',
+      code: 'BG_LOCATION_REQUIRED',
+    });
+
+    filter.catch(exc, host);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.code).toBe('BG_LOCATION_REQUIRED');
+  });
+
+  it('omits `code` when the response payload has no code field', () => {
+    const { host, res } = makeHost();
+    filter.catch(new BadRequestException('plain'), host);
+    expect(res.json.mock.calls[0][0]).not.toHaveProperty('code');
+  });
+
+  it('includes `error` (stack) only in development', () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    try {
+      const { host, res } = makeHost();
+      filter.catch(new Error('boom'), host);
+      expect(res.json.mock.calls[0][0]).toHaveProperty('error');
+    } finally {
+      process.env.NODE_ENV = original;
+    }
+
+    process.env.NODE_ENV = 'production';
+    try {
+      const { host, res } = makeHost();
+      filter.catch(new Error('boom'), host);
+      expect(res.json.mock.calls[0][0]).not.toHaveProperty('error');
+    } finally {
+      process.env.NODE_ENV = original;
+    }
+  });
+});

--- a/apps/backend/src/common/filters/all-exceptions.filter.ts
+++ b/apps/backend/src/common/filters/all-exceptions.filter.ts
@@ -6,21 +6,23 @@ import {
   HttpStatus,
   Logger,
 } from '@nestjs/common';
-import { SentryExceptionCaptured } from '@sentry/nestjs';
+import * as Sentry from '@sentry/nestjs';
 import { Request, Response } from 'express';
 
 /**
  * Global exception filter that standardizes error responses across the API.
  * Logs all errors and includes stack traces in development mode.
  *
- * `@SentryExceptionCaptured()` reports unhandled exceptions to Sentry while
- * still allowing this filter to control the HTTP response shape.
+ * Sentry capture is gated to status >= 500 (or non-HttpException). Client
+ * errors (4xx) are logged at warn level without a stack trace — they are
+ * almost always either user input mistakes or internet scanners hitting
+ * non-existent paths (`/elanpaymentsolutions`, `/wp-login.php`, etc.) and
+ * reporting them to Sentry pollutes the issue feed and burns quota.
  */
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {
   private readonly logger = new Logger(AllExceptionsFilter.name);
 
-  @SentryExceptionCaptured()
   catch(exception: unknown, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
@@ -64,10 +66,19 @@ export class AllExceptionsFilter implements ExceptionFilter {
       }),
     };
 
-    this.logger.error(
-      `${request.method} ${request.url} - ${status} - ${message}`,
-      exception instanceof Error ? exception.stack : String(exception),
-    );
+    if (status >= 500) {
+      this.logger.error(
+        `${request.method} ${request.url} - ${status} - ${message}`,
+        exception instanceof Error ? exception.stack : String(exception),
+      );
+      Sentry.captureException(exception);
+    } else {
+      // 4xx: log without stack (client error, not a server bug) and don't
+      // pollute Sentry with scanner noise / user input mistakes.
+      this.logger.warn(
+        `${request.method} ${request.url} - ${status} - ${message}`,
+      );
+    }
 
     response.status(status).json(errorResponse);
   }

--- a/apps/backend/src/database/database.module.ts
+++ b/apps/backend/src/database/database.module.ts
@@ -32,11 +32,17 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
     const writeUrl = process.env.DATABASE_URL;
     const readUrl = process.env.DATABASE_URL_RO?.trim() || writeUrl;
 
+    // connectionTimeoutMillis 15s (was 5s) covers Neon's cold-compute
+    // wake-up window. When the serverless compute is suspended, the first
+    // pool.connect() can take 5-10s while Neon resumes; 5s caused
+    // "Connection terminated due to connection timeout" failures inside
+    // withAdvisoryLock for cron jobs that fired right when the compute
+    // happened to be cold.
     const pool = new pg.Pool({
       connectionString: writeUrl,
       max: isProduction ? 8 : 5,
       idleTimeoutMillis: 30_000,
-      connectionTimeoutMillis: 5_000,
+      connectionTimeoutMillis: 15_000,
       ...(isProduction && { ssl: { rejectUnauthorized: true } }),
     });
 
@@ -54,11 +60,18 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
           connectionString: readUrl,
           max: isProduction ? 8 : 3,
           idleTimeoutMillis: 30_000,
-          connectionTimeoutMillis: 5_000,
+          connectionTimeoutMillis: 15_000,
           ...(isProduction && { ssl: { rejectUnauthorized: true } }),
         })
       : pool;
   }
+
+  // Nest can invoke onModuleDestroy more than once during shutdown when
+  // both the global shutdown hook and an explicit app.close() fire (and
+  // the same instance is provided to multiple modules in some test setups).
+  // pg.Pool throws "Called end on pool more than once" on the second call,
+  // which surfaces as a Sentry error during otherwise-clean shutdowns.
+  private destroyed = false;
 
   async onModuleInit() {
     await this.$connect();
@@ -68,6 +81,8 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
   }
 
   async onModuleDestroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
     await this.$disconnect();
     await this.pool.end();
     if (this.hasDedicatedReader) {

--- a/apps/backend/src/scripts/_bootstrap.spec.ts
+++ b/apps/backend/src/scripts/_bootstrap.spec.ts
@@ -1,0 +1,204 @@
+jest.mock('../instrument', () => ({}));
+
+const mockNestFactory = {
+  createApplicationContext: jest.fn(),
+};
+jest.mock('@nestjs/core', () => ({
+  NestFactory: mockNestFactory,
+}));
+
+const mockSentry = {
+  captureCheckIn: jest.fn().mockReturnValue('check-in-id'),
+  captureException: jest.fn(),
+  flush: jest.fn().mockResolvedValue(true),
+};
+jest.mock('@sentry/nestjs', () => mockSentry);
+
+const mockWithAdvisoryLock = jest.fn();
+jest.mock('./_advisory-lock', () => ({
+  withAdvisoryLock: (...args: unknown[]) => mockWithAdvisoryLock(...args),
+}));
+
+const mockMonitors: Record<string, unknown> = {};
+jest.mock('./_cron-monitors', () => ({
+  CRON_MONITORS: mockMonitors,
+  CRON_TIMEZONE: 'America/New_York',
+}));
+
+jest.mock('./_cron-app.module', () => ({
+  CronAppModule: {
+    withFeatures: jest.fn().mockReturnValue(class FakeCronApp {}),
+  },
+}));
+
+import { Logger as PinoLogger } from 'nestjs-pino';
+import { runCronJob } from './_bootstrap';
+import { PrismaService } from '../database/database.module';
+
+const FAKE_POOL = { _pool: true };
+
+function makeApp(extra: Record<string, unknown> = {}) {
+  const logger = {
+    log: jest.fn(),
+    error: jest.fn(),
+  };
+  const prisma = { pool: FAKE_POOL } as unknown as PrismaService;
+  const app = {
+    get: jest.fn((token: unknown) => {
+      if (token === PinoLogger) return logger;
+      if (token === PrismaService) return prisma;
+      return extra[String(token)];
+    }),
+    useLogger: jest.fn(),
+    enableShutdownHooks: jest.fn(),
+    close: jest.fn().mockResolvedValue(undefined),
+  };
+  return { app, logger };
+}
+
+describe('runCronJob', () => {
+  const exitSpy = jest
+    .spyOn(process, 'exit')
+    .mockImplementation((() => undefined) as never);
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  const originalDsn = process.env.SENTRY_DSN;
+
+  beforeEach(() => {
+    exitSpy.mockClear();
+    consoleErrorSpy.mockClear();
+    mockNestFactory.createApplicationContext.mockReset();
+    mockWithAdvisoryLock.mockReset();
+    mockSentry.captureCheckIn.mockClear().mockReturnValue('check-in-id');
+    mockSentry.captureException.mockClear();
+    mockSentry.flush.mockClear().mockResolvedValue(true);
+    for (const k of Object.keys(mockMonitors)) delete mockMonitors[k];
+    process.env.SENTRY_DSN = 'https://example@sentry.io/1';
+  });
+
+  afterAll(() => {
+    exitSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    if (originalDsn === undefined) delete process.env.SENTRY_DSN;
+    else process.env.SENTRY_DSN = originalDsn;
+  });
+
+  it('runs work, closes the check-in as ok, and exits 0', async () => {
+    mockMonitors['ok-job'] = { schedule: '* * * * *', checkinMargin: 1, maxRuntime: 5 };
+    const { app, logger } = makeApp();
+    mockNestFactory.createApplicationContext.mockResolvedValue(app);
+    mockWithAdvisoryLock.mockImplementation(async (_pool, _name, fn) => {
+      await fn();
+      return { acquired: true };
+    });
+    const work = jest.fn().mockResolvedValue(undefined);
+
+    await runCronJob('ok-job', [], work);
+
+    expect(work).toHaveBeenCalledTimes(1);
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('starting'));
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('complete'));
+    expect(mockSentry.captureCheckIn).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ monitorSlug: 'ok-job', status: 'in_progress' }),
+      expect.any(Object),
+    );
+    expect(mockSentry.captureCheckIn).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        checkInId: 'check-in-id',
+        monitorSlug: 'ok-job',
+        status: 'ok',
+      }),
+    );
+    expect(app.close).toHaveBeenCalled();
+    expect(mockSentry.flush).toHaveBeenCalledWith(2000);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('skips and logs when another instance holds the advisory lock', async () => {
+    mockMonitors['skip-job'] = { schedule: '* * * * *', checkinMargin: 1, maxRuntime: 5 };
+    const { app, logger } = makeApp();
+    mockNestFactory.createApplicationContext.mockResolvedValue(app);
+    mockWithAdvisoryLock.mockResolvedValue({ acquired: false });
+    const work = jest.fn();
+
+    await runCronJob('skip-job', [], work);
+
+    expect(work).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('another instance holds the lock — skipping'),
+    );
+    // Skip path still closes the check-in as ok (avoids missed-check-in alert)
+    expect(mockSentry.captureCheckIn).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: 'ok' }),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('captures exceptions, closes check-in as error, and exits 1 when work throws', async () => {
+    mockMonitors['fail-job'] = { schedule: '* * * * *', checkinMargin: 1, maxRuntime: 5 };
+    const { app, logger } = makeApp();
+    mockNestFactory.createApplicationContext.mockResolvedValue(app);
+    const boom = new Error('boom');
+    mockWithAdvisoryLock.mockImplementation(async (_pool, _name, fn) => {
+      await fn();
+      return { acquired: true };
+    });
+    const work = jest.fn().mockRejectedValue(boom);
+
+    await runCronJob('fail-job', [], work);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('failed: boom'),
+      expect.any(String),
+    );
+    expect(mockSentry.captureCheckIn).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: 'error', monitorSlug: 'fail-job' }),
+    );
+    expect(mockSentry.captureException).toHaveBeenCalledWith(boom);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('falls back to console.error when bootstrap itself fails', async () => {
+    const bootErr = new Error('nest boot failed');
+    mockNestFactory.createApplicationContext.mockRejectedValue(bootErr);
+
+    await runCronJob('boot-fail', [], jest.fn());
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('boot-fail] failed before bootstrap'),
+      bootErr,
+    );
+    expect(mockSentry.captureException).toHaveBeenCalledWith(bootErr);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('does not open a Sentry check-in when no monitor config is registered', async () => {
+    const { app } = makeApp();
+    mockNestFactory.createApplicationContext.mockResolvedValue(app);
+    mockWithAdvisoryLock.mockImplementation(async (_pool, _name, fn) => {
+      await fn();
+      return { acquired: true };
+    });
+
+    await runCronJob('unmonitored', [], jest.fn().mockResolvedValue(undefined));
+
+    expect(mockSentry.captureCheckIn).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('does not open a Sentry check-in when SENTRY_DSN is unset', async () => {
+    mockMonitors['no-dsn'] = { schedule: '* * * * *', checkinMargin: 1, maxRuntime: 5 };
+    delete process.env.SENTRY_DSN;
+    const { app } = makeApp();
+    mockNestFactory.createApplicationContext.mockResolvedValue(app);
+    mockWithAdvisoryLock.mockImplementation(async (_pool, _name, fn) => {
+      await fn();
+      return { acquired: true };
+    });
+
+    await runCronJob('no-dsn', [], jest.fn().mockResolvedValue(undefined));
+
+    expect(mockSentry.captureCheckIn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/scripts/_bootstrap.ts
+++ b/apps/backend/src/scripts/_bootstrap.ts
@@ -4,9 +4,9 @@ import '../instrument';
 
 import * as Sentry from '@sentry/nestjs';
 import { NestFactory } from '@nestjs/core';
-import type { INestApplicationContext } from '@nestjs/common';
+import type { INestApplicationContext, Type } from '@nestjs/common';
 import { Logger as PinoLogger } from 'nestjs-pino';
-import { AppModule } from '../app.module';
+import { CronAppModule } from './_cron-app.module';
 import { PrismaService } from '../database/database.module';
 import { withAdvisoryLock } from './_advisory-lock';
 import { CRON_MONITORS, CRON_TIMEZONE } from './_cron-monitors';
@@ -22,12 +22,19 @@ export interface CronContext {
  * one-shot cron scripts. Returns the running context plus convenience handles
  * to Prisma and the pino logger.
  *
+ * `features` is the list of feature modules this script needs (e.g.
+ * `[OccupancyEventsModule]`). Keep it as small as possible — every module
+ * imported here costs RSS, and 5 concurrent cron ticks share the cron VM.
+ *
  * Caller is responsible for awaiting `app.close()` when done.
  */
-export async function bootstrapCronContext(): Promise<CronContext> {
-  const app = await NestFactory.createApplicationContext(AppModule, {
-    bufferLogs: true,
-  });
+export async function bootstrapCronContext(
+  features: Type<unknown>[] = [],
+): Promise<CronContext> {
+  const app = await NestFactory.createApplicationContext(
+    CronAppModule.withFeatures(features),
+    { bufferLogs: true },
+  );
   const logger = app.get(PinoLogger);
   app.useLogger(logger);
   app.enableShutdownHooks();
@@ -42,12 +49,13 @@ export async function bootstrapCronContext(): Promise<CronContext> {
  *
  * Use as the script entry point:
  *
- *   void runCronJob('snapshot', async ({ app }) => {
- *     await app.get(MyService).doThing();
+ *   void runCronJob('snapshot', [OccupancyEventsModule], async ({ app }) => {
+ *     await app.get(OccupancyEventsService).createSnapshots();
  *   });
  */
 export async function runCronJob(
   jobName: string,
+  features: Type<unknown>[],
   work: (ctx: CronContext) => Promise<void>,
 ): Promise<void> {
   let ctx: CronContext | undefined;
@@ -72,7 +80,7 @@ export async function runCronJob(
   }
 
   try {
-    ctx = await bootstrapCronContext();
+    ctx = await bootstrapCronContext(features);
     const log = ctx.logger;
     log.log(`[cron:${jobName}] starting`);
 

--- a/apps/backend/src/scripts/_cron-app.module.ts
+++ b/apps/backend/src/scripts/_cron-app.module.ts
@@ -1,0 +1,75 @@
+import { DynamicModule, Module, Type } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { LoggerModule } from 'nestjs-pino';
+import { SentryModule } from '@sentry/nestjs/setup';
+import { DatabaseModule } from '../database/database.module';
+import {
+  appConfig,
+  authConfig,
+  dbConfig,
+  privacyConfig,
+  weatherConfig,
+  notificationsConfig,
+  validateConfig,
+} from '../config/configuration';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+/**
+ * Per-script Nest module for one-shot cron jobs.
+ *
+ * Includes only the always-on dependencies every cron needs:
+ *   - ConfigModule (env-driven feature configs)
+ *   - SentryModule (error capture + check-ins, instrumented in instrument.ts)
+ *   - LoggerModule (pino, mirrored from AppModule)
+ *   - DatabaseModule (PrismaService — needed for the advisory lock alone)
+ *
+ * Callers pass the 1–2 feature modules the script actually invokes via
+ * `withFeatures([...])`. This avoids loading the full AppModule on every cron
+ * tick — most importantly `ShuttleTrackerModule` (opens a PassioGo WebSocket
+ * in onModuleInit) and `NotificationsModule` (initializes Firebase Admin).
+ *
+ * Bootstrapping the full AppModule cost ~180 MB RSS per script. Five
+ * concurrent `*&#47;15` cron ticks (snapshot + 4 notify-* jobs) saturated the
+ * 1 GB cron VM and triggered OOM kills. Per-script modules drop each
+ * bootstrap to ~60 MB so all five fit under 500 MB.
+ */
+@Module({})
+export class CronAppModule {
+  static withFeatures(features: Type<unknown>[]): DynamicModule {
+    return {
+      module: CronAppModule,
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [
+            appConfig,
+            authConfig,
+            dbConfig,
+            privacyConfig,
+            weatherConfig,
+            notificationsConfig,
+          ],
+          validate: validateConfig,
+        }),
+        SentryModule.forRoot(),
+        LoggerModule.forRoot({
+          pinoHttp: {
+            level: process.env.LOG_LEVEL ?? (isProduction ? 'info' : 'debug'),
+            customProps: () => ({ service: 'sharkpark-backend' }),
+            ...(isProduction
+              ? {}
+              : {
+                  transport: {
+                    target: 'pino-pretty',
+                    options: { singleLine: true, translateTime: 'SYS:HH:MM:ss.l' },
+                  },
+                }),
+          },
+        }),
+        DatabaseModule,
+        ...features,
+      ],
+    };
+  }
+}

--- a/apps/backend/src/scripts/backup-db.spec.ts
+++ b/apps/backend/src/scripts/backup-db.spec.ts
@@ -1,0 +1,116 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough, Readable } from 'node:stream';
+import { setImmediate } from 'node:timers';
+
+jest.mock('./_bootstrap', () => ({ runCronJob: jest.fn() }));
+
+const mockUploadDone = jest.fn().mockResolvedValue({ ETag: '"abc"' });
+const MockUploadCtor = jest.fn().mockImplementation(() => ({ done: mockUploadDone }));
+jest.mock('@aws-sdk/lib-storage', () => ({
+  Upload: MockUploadCtor,
+}));
+
+const MockS3Ctor = jest.fn().mockImplementation(() => ({}));
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: MockS3Ctor,
+}));
+
+const mockSpawn = jest.fn();
+jest.mock('node:child_process', () => ({ spawn: mockSpawn }));
+
+import { runCronJob } from './_bootstrap';
+import './backup-db';
+
+type WorkFn = (ctx: { logger: { log: jest.Mock } }) => Promise<void>;
+
+const REQUIRED_ENV = {
+  DIRECT_URL: 'postgres://u:p@host/db',
+  R2_ACCOUNT_ID: 'acct',
+  R2_ACCESS_KEY_ID: 'ak',
+  R2_SECRET_ACCESS_KEY: 'sk',
+  R2_BACKUPS_BUCKET: 'bucket',
+};
+
+function setEnv(env: Record<string, string | undefined>) {
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+function makePgDump(exitCode = 0) {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: Readable;
+    stderr: Readable;
+  };
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
+  // schedule exit on next tick so the script has time to wire pipes
+  setImmediate(() => {
+    (proc.stdout as PassThrough).end();
+    proc.emit('exit', exitCode);
+  });
+  return proc;
+}
+
+describe('backup-db cron', () => {
+  const call = (runCronJob as jest.Mock).mock.calls[0];
+  const work = call[2] as WorkFn;
+  const original = { ...process.env };
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    MockUploadCtor.mockClear();
+    MockS3Ctor.mockClear();
+    mockUploadDone.mockClear().mockResolvedValue({ ETag: '"abc"' });
+    setEnv(REQUIRED_ENV);
+  });
+
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  it('registers as backup-db with no extra feature modules', () => {
+    expect(call[0]).toBe('backup-db');
+    expect(call[1]).toEqual([]);
+  });
+
+  it.each(Object.keys(REQUIRED_ENV))('throws when %s is missing', async (key) => {
+    setEnv({ [key]: undefined });
+    const logger = { log: jest.fn() };
+    await expect(work({ logger })).rejects.toThrow(/missing one of/);
+  });
+
+  it('spawns pg_dump and streams it through gzip into an S3 multipart upload', async () => {
+    mockSpawn.mockReturnValue(makePgDump(0));
+    const logger = { log: jest.fn() };
+
+    await work({ logger });
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'pg_dump',
+      expect.arrayContaining(['--format=custom', REQUIRED_ENV.DIRECT_URL]),
+      expect.any(Object),
+    );
+    expect(MockS3Ctor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: `https://${REQUIRED_ENV.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+      }),
+    );
+    const uploadParams = MockUploadCtor.mock.calls[0][0];
+    expect(uploadParams.params).toMatchObject({
+      Bucket: REQUIRED_ENV.R2_BACKUPS_BUCKET,
+      ContentEncoding: 'gzip',
+    });
+    expect(uploadParams.params.Key).toMatch(/^daily\/\d{4}-\d{2}-\d{2}\.dump\.gz$/);
+    expect(mockUploadDone).toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('uploaded daily/'));
+  });
+
+  it('rejects when pg_dump exits non-zero', async () => {
+    mockSpawn.mockReturnValue(makePgDump(1));
+    await expect(work({ logger: { log: jest.fn() } })).rejects.toThrow(
+      /pg_dump exited 1/,
+    );
+  });
+});

--- a/apps/backend/src/scripts/backup-db.ts
+++ b/apps/backend/src/scripts/backup-db.ts
@@ -20,7 +20,7 @@ import { runCronJob } from './_bootstrap';
  *   R2_SECRET_ACCESS_KEY        R2 token secret
  *   R2_BACKUPS_BUCKET           Bucket name (e.g. sharkpark-backups)
  */
-void runCronJob('backup-db', async ({ logger }) => {
+void runCronJob('backup-db', [], async ({ logger }) => {
   const dbUrl = process.env.DIRECT_URL;
   const accountId = process.env.R2_ACCOUNT_ID;
   const accessKeyId = process.env.R2_ACCESS_KEY_ID;

--- a/apps/backend/src/scripts/cleanup-device-states.spec.ts
+++ b/apps/backend/src/scripts/cleanup-device-states.spec.ts
@@ -1,0 +1,32 @@
+jest.mock('./_bootstrap', () => ({ runCronJob: jest.fn() }));
+
+import { runCronJob } from './_bootstrap';
+import { OccupancyEventsModule } from '../occupancy-events/occupancy-events.module';
+import './cleanup-device-states';
+
+type WorkFn = (ctx: { app: unknown; logger: unknown }) => Promise<void>;
+
+describe('cleanup-device-states cron', () => {
+  const call = (runCronJob as jest.Mock).mock.calls[0];
+
+  it('registers under cleanup-device-states with [OccupancyEventsModule]', () => {
+    expect(call[0]).toBe('cleanup-device-states');
+    expect(call[1]).toEqual([OccupancyEventsModule]);
+  });
+
+  it('calls cleanupStaleDeviceStates(18h) and logs how many were cleaned', async () => {
+    const work = call[2] as WorkFn;
+    const svc = {
+      cleanupStaleDeviceStates: jest.fn().mockResolvedValue({ cleaned: 7 }),
+    };
+    const logger = { log: jest.fn() };
+    const app = { get: jest.fn().mockReturnValue(svc) };
+
+    await work({ app, logger });
+
+    expect(svc.cleanupStaleDeviceStates).toHaveBeenCalledWith(18);
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('cleaned 7 stale ENTER records'),
+    );
+  });
+});

--- a/apps/backend/src/scripts/cleanup-device-states.ts
+++ b/apps/backend/src/scripts/cleanup-device-states.ts
@@ -1,9 +1,10 @@
 import { runCronJob } from './_bootstrap';
+import { OccupancyEventsModule } from '../occupancy-events/occupancy-events.module';
 import { OccupancyEventsService } from '../occupancy-events/occupancy-events.service';
 
 const STALE_AGE_HOURS = 18;
 
-void runCronJob('cleanup-device-states', async ({ app, logger }) => {
+void runCronJob('cleanup-device-states', [OccupancyEventsModule], async ({ app, logger }) => {
   const svc = app.get(OccupancyEventsService);
   const result = await svc.cleanupStaleDeviceStates(STALE_AGE_HOURS);
   logger.log(

--- a/apps/backend/src/scripts/fetch-transit.spec.ts
+++ b/apps/backend/src/scripts/fetch-transit.spec.ts
@@ -1,0 +1,37 @@
+jest.mock('./_bootstrap', () => ({ runCronJob: jest.fn() }));
+
+import { runCronJob } from './_bootstrap';
+import { RedisModule } from '../redis/redis.module';
+import { ShuttleTrackerCoreModule } from '../shuttle-tracker/shuttle-tracker-core.module';
+import './fetch-transit';
+
+type WorkFn = (ctx: { app: unknown }) => Promise<void>;
+
+describe('fetch-transit cron', () => {
+  const call = (runCronJob as jest.Mock).mock.calls[0];
+
+  it('registers as fetch-transit with [RedisModule, ShuttleTrackerCoreModule]', () => {
+    expect(call[0]).toBe('fetch-transit');
+    expect(call[1]).toEqual([RedisModule, ShuttleTrackerCoreModule]);
+  });
+
+  it('calls fetchRoutesAndStops then fetchShuttles', async () => {
+    const work = call[2] as WorkFn;
+    const order: string[] = [];
+    const svc = {
+      fetchRoutesAndStops: jest.fn().mockImplementation(async () => {
+        order.push('routes');
+      }),
+      fetchShuttles: jest.fn().mockImplementation(async () => {
+        order.push('shuttles');
+      }),
+    };
+    const app = { get: jest.fn().mockReturnValue(svc) };
+
+    await work({ app });
+
+    expect(svc.fetchRoutesAndStops).toHaveBeenCalledTimes(1);
+    expect(svc.fetchShuttles).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['routes', 'shuttles']);
+  });
+});

--- a/apps/backend/src/scripts/fetch-transit.ts
+++ b/apps/backend/src/scripts/fetch-transit.ts
@@ -1,13 +1,14 @@
 import { runCronJob } from './_bootstrap';
 import { RedisModule } from '../redis/redis.module';
-import { ShuttleTrackerModule } from '../shuttle-tracker/shuttle-tracker.module';
+import { ShuttleTrackerCoreModule } from '../shuttle-tracker/shuttle-tracker-core.module';
 import { ShuttleTrackerService } from '../shuttle-tracker/shuttle-tracker.service';
 
-// TODO: ShuttleTrackerModule pulls in PassioWebSocketService + Gateway, which
-// open a WebSocket on bootstrap. Acceptable here because fetch-transit runs
-// alone (daily, 0 0) and isn't part of the */15 cron cluster that drives RSS.
-void runCronJob('fetch-transit', [RedisModule, ShuttleTrackerModule], async ({ app }) => {
-  const svc = app.get(ShuttleTrackerService);
-  await svc.fetchRoutesAndStops();
-  await svc.fetchShuttles();
-});
+void runCronJob(
+  'fetch-transit',
+  [RedisModule, ShuttleTrackerCoreModule],
+  async ({ app }) => {
+    const svc = app.get(ShuttleTrackerService);
+    await svc.fetchRoutesAndStops();
+    await svc.fetchShuttles();
+  },
+);

--- a/apps/backend/src/scripts/fetch-transit.ts
+++ b/apps/backend/src/scripts/fetch-transit.ts
@@ -1,7 +1,12 @@
 import { runCronJob } from './_bootstrap';
+import { RedisModule } from '../redis/redis.module';
+import { ShuttleTrackerModule } from '../shuttle-tracker/shuttle-tracker.module';
 import { ShuttleTrackerService } from '../shuttle-tracker/shuttle-tracker.service';
 
-void runCronJob('fetch-transit', async ({ app }) => {
+// TODO: ShuttleTrackerModule pulls in PassioWebSocketService + Gateway, which
+// open a WebSocket on bootstrap. Acceptable here because fetch-transit runs
+// alone (daily, 0 0) and isn't part of the */15 cron cluster that drives RSS.
+void runCronJob('fetch-transit', [RedisModule, ShuttleTrackerModule], async ({ app }) => {
   const svc = app.get(ShuttleTrackerService);
   await svc.fetchRoutesAndStops();
   await svc.fetchShuttles();

--- a/apps/backend/src/scripts/fetch-weather-forecast.spec.ts
+++ b/apps/backend/src/scripts/fetch-weather-forecast.spec.ts
@@ -1,0 +1,26 @@
+jest.mock('./_bootstrap', () => ({ runCronJob: jest.fn() }));
+
+import { runCronJob } from './_bootstrap';
+import { WeatherModule } from '../weather/weather.module';
+import './fetch-weather-forecast';
+
+type WorkFn = (ctx: { app: unknown }) => Promise<void>;
+
+describe('fetch-weather-forecast cron', () => {
+  const call = (runCronJob as jest.Mock).mock.calls[0];
+
+  it('registers as fetch-weather-forecast with [WeatherModule]', () => {
+    expect(call[0]).toBe('fetch-weather-forecast');
+    expect(call[1]).toEqual([WeatherModule]);
+  });
+
+  it('calls WeatherForecastFetchService.fetchForecast()', async () => {
+    const work = call[2] as WorkFn;
+    const svc = { fetchForecast: jest.fn().mockResolvedValue(undefined) };
+    const app = { get: jest.fn().mockReturnValue(svc) };
+
+    await work({ app });
+
+    expect(svc.fetchForecast).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/scripts/fetch-weather-forecast.ts
+++ b/apps/backend/src/scripts/fetch-weather-forecast.ts
@@ -1,7 +1,8 @@
 import { runCronJob } from './_bootstrap';
+import { WeatherModule } from '../weather/weather.module';
 import { WeatherForecastFetchService } from '../weather/weather-forecast-fetch.service';
 
-void runCronJob('fetch-weather-forecast', async ({ app }) => {
+void runCronJob('fetch-weather-forecast', [WeatherModule], async ({ app }) => {
   const svc = app.get(WeatherForecastFetchService);
   await svc.fetchForecast();
 });

--- a/apps/backend/src/scripts/fetch-weather.spec.ts
+++ b/apps/backend/src/scripts/fetch-weather.spec.ts
@@ -1,0 +1,26 @@
+jest.mock('./_bootstrap', () => ({ runCronJob: jest.fn() }));
+
+import { runCronJob } from './_bootstrap';
+import { WeatherModule } from '../weather/weather.module';
+import './fetch-weather';
+
+type WorkFn = (ctx: { app: unknown }) => Promise<void>;
+
+describe('fetch-weather cron', () => {
+  const call = (runCronJob as jest.Mock).mock.calls[0];
+
+  it('registers as fetch-weather with [WeatherModule]', () => {
+    expect(call[0]).toBe('fetch-weather');
+    expect(call[1]).toEqual([WeatherModule]);
+  });
+
+  it('calls WeatherFetchService.fetchWeather()', async () => {
+    const work = call[2] as WorkFn;
+    const svc = { fetchWeather: jest.fn().mockResolvedValue(undefined) };
+    const app = { get: jest.fn().mockReturnValue(svc) };
+
+    await work({ app });
+
+    expect(svc.fetchWeather).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/scripts/fetch-weather.ts
+++ b/apps/backend/src/scripts/fetch-weather.ts
@@ -1,7 +1,8 @@
 import { runCronJob } from './_bootstrap';
+import { WeatherModule } from '../weather/weather.module';
 import { WeatherFetchService } from '../weather/weather-fetch.service';
 
-void runCronJob('fetch-weather', async ({ app }) => {
+void runCronJob('fetch-weather', [WeatherModule], async ({ app }) => {
   const svc = app.get(WeatherFetchService);
   await svc.fetchWeather();
 });

--- a/apps/backend/src/scripts/notify-events.spec.ts
+++ b/apps/backend/src/scripts/notify-events.spec.ts
@@ -31,7 +31,7 @@ describe('notify-events', () => {
   let work: WorkFn;
 
   beforeAll(() => {
-    work = (runCronJob as jest.Mock).mock.calls[0][1];
+    work = (runCronJob as jest.Mock).mock.calls[0][2];
   });
 
   it('early-returns when no events are in the 2-hour window', async () => {

--- a/apps/backend/src/scripts/notify-events.ts
+++ b/apps/backend/src/scripts/notify-events.ts
@@ -1,5 +1,6 @@
 import { NotificationType } from '@prisma/client';
 import { runCronJob } from './_bootstrap';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { NotificationsService } from '../notifications/notifications.service';
 
 // Notify when an event starts within the next 2 hours
@@ -11,7 +12,7 @@ function formatLocalTime(date: Date, tz: string): string {
   return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZone: tz });
 }
 
-void runCronJob('notify-events', async ({ app, prisma, logger }) => {
+void runCronJob('notify-events', [NotificationsModule], async ({ app, prisma, logger }) => {
   const svc = app.get(NotificationsService);
   const now = new Date();
   const lookahead = new Date(now.getTime() + LOOKAHEAD_MS);

--- a/apps/backend/src/scripts/notify-favorites-clearing.spec.ts
+++ b/apps/backend/src/scripts/notify-favorites-clearing.spec.ts
@@ -34,7 +34,7 @@ describe('notify-favorites-clearing', () => {
   let work: WorkFn;
 
   beforeAll(() => {
-    work = (runCronJob as jest.Mock).mock.calls[0][1];
+    work = (runCronJob as jest.Mock).mock.calls[0][2];
   });
 
   it('early-returns when no lots are below 30%', async () => {

--- a/apps/backend/src/scripts/notify-favorites-clearing.ts
+++ b/apps/backend/src/scripts/notify-favorites-clearing.ts
@@ -1,11 +1,12 @@
 import { NotificationType } from '@prisma/client';
 import { runCronJob } from './_bootstrap';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { NotificationsService } from '../notifications/notifications.service';
 
 const SNAPSHOT_WINDOW_MS = 20 * 60 * 1000;
 const DEDUP_WINDOW_MS = 4 * 60 * 60 * 1000;
 
-void runCronJob('notify-favorites-clearing', async ({ app, prisma, logger }) => {
+void runCronJob('notify-favorites-clearing', [NotificationsModule], async ({ app, prisma, logger }) => {
   const svc = app.get(NotificationsService);
   const now = Date.now();
   const recentCutoff = new Date(now - SNAPSHOT_WINDOW_MS);

--- a/apps/backend/src/scripts/notify-favorites-filling.spec.ts
+++ b/apps/backend/src/scripts/notify-favorites-filling.spec.ts
@@ -31,7 +31,7 @@ describe('notify-favorites-filling', () => {
   let work: WorkFn;
 
   beforeAll(() => {
-    work = (runCronJob as jest.Mock).mock.calls[0][1];
+    work = (runCronJob as jest.Mock).mock.calls[0][2];
   });
 
   it('early-returns when no lots are above 80%', async () => {

--- a/apps/backend/src/scripts/notify-favorites-filling.ts
+++ b/apps/backend/src/scripts/notify-favorites-filling.ts
@@ -1,5 +1,6 @@
 import { NotificationType } from '@prisma/client';
 import { runCronJob } from './_bootstrap';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { NotificationsService } from '../notifications/notifications.service';
 
 // Alert window: treat a snapshot from the last 20 min as "current" to
@@ -8,7 +9,7 @@ const SNAPSHOT_WINDOW_MS = 20 * 60 * 1000;
 // Dedup: don't re-alert the same user about the same lot within 4 hours
 const DEDUP_WINDOW_MS = 4 * 60 * 60 * 1000;
 
-void runCronJob('notify-favorites-filling', async ({ app, prisma, logger }) => {
+void runCronJob('notify-favorites-filling', [NotificationsModule], async ({ app, prisma, logger }) => {
   const svc = app.get(NotificationsService);
   const since = new Date(Date.now() - SNAPSHOT_WINDOW_MS);
 

--- a/apps/backend/src/scripts/notify-surge.spec.ts
+++ b/apps/backend/src/scripts/notify-surge.spec.ts
@@ -30,7 +30,7 @@ describe('notify-surge', () => {
   let work: WorkFn;
 
   beforeAll(() => {
-    work = (runCronJob as jest.Mock).mock.calls[0][1];
+    work = (runCronJob as jest.Mock).mock.calls[0][2];
   });
 
   it('early-returns when no lots are above 90%', async () => {

--- a/apps/backend/src/scripts/notify-surge.ts
+++ b/apps/backend/src/scripts/notify-surge.ts
@@ -1,12 +1,13 @@
 import { NotificationType } from '@prisma/client';
 import { runCronJob } from './_bootstrap';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { NotificationsService } from '../notifications/notifications.service';
 
 const SNAPSHOT_WINDOW_MS = 20 * 60 * 1000;
 // Surge is a campus-wide condition — don't re-alert any user for 2 hours
 const DEDUP_WINDOW_MS = 2 * 60 * 60 * 1000;
 
-void runCronJob('notify-surge', async ({ app, prisma, logger }) => {
+void runCronJob('notify-surge', [NotificationsModule], async ({ app, prisma, logger }) => {
   const svc = app.get(NotificationsService);
   const since = new Date(Date.now() - SNAPSHOT_WINDOW_MS);
 

--- a/apps/backend/src/scripts/prune-old-data.spec.ts
+++ b/apps/backend/src/scripts/prune-old-data.spec.ts
@@ -1,0 +1,79 @@
+jest.mock('./_bootstrap', () => ({ runCronJob: jest.fn() }));
+
+import { runCronJob } from './_bootstrap';
+
+type WorkFn = (ctx: { app: unknown; logger: unknown }) => Promise<void>;
+
+function loadFresh(): WorkFn {
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, no-undef
+    require('./prune-old-data');
+  });
+  const calls = (runCronJob as jest.Mock).mock.calls;
+  return calls[calls.length - 1][2];
+}
+
+describe('prune-old-data cron', () => {
+  beforeEach(() => {
+    (runCronJob as jest.Mock).mockClear();
+    delete process.env.RETENTION_DAYS;
+  });
+
+  it('registers as prune-old-data with [OccupancyEventsModule]', () => {
+    loadFresh();
+    const call = (runCronJob as jest.Mock).mock.calls[0];
+    expect(call[0]).toBe('prune-old-data');
+    // Use class name rather than identity: jest.isolateModules re-evaluates
+    // the script, which re-requires the module under a fresh module cache.
+    expect(call[1]).toHaveLength(1);
+    expect((call[1][0] as { name: string }).name).toBe('OccupancyEventsModule');
+  });
+
+  it('uses the 30-day default retention when RETENTION_DAYS is unset', async () => {
+    const work = loadFresh();
+    const svc = {
+      pruneOldData: jest
+        .fn()
+        .mockResolvedValue({ events_deleted: 0, cutoff: '2026-04-03' }),
+    };
+    const logger = { log: jest.fn() };
+    const app = { get: jest.fn().mockReturnValue(svc) };
+
+    await work({ app, logger });
+
+    expect(svc.pruneOldData).toHaveBeenCalledWith(30);
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('retention=30d'),
+    );
+  });
+
+  it('honors a numeric RETENTION_DAYS override', async () => {
+    process.env.RETENTION_DAYS = '60';
+    const work = loadFresh();
+    const svc = {
+      pruneOldData: jest
+        .fn()
+        .mockResolvedValue({ events_deleted: 5, cutoff: '2026-03-04' }),
+    };
+    const app = { get: jest.fn().mockReturnValue(svc) };
+
+    await work({ app, logger: { log: jest.fn() } });
+
+    expect(svc.pruneOldData).toHaveBeenCalledWith(60);
+  });
+
+  it('throws on a non-numeric or sub-1 RETENTION_DAYS', async () => {
+    process.env.RETENTION_DAYS = 'abc';
+    const work = loadFresh();
+    const app = { get: jest.fn() };
+    await expect(work({ app, logger: { log: jest.fn() } })).rejects.toThrow(
+      /RETENTION_DAYS must be a number/,
+    );
+
+    process.env.RETENTION_DAYS = '0';
+    const work2 = loadFresh();
+    await expect(work2({ app, logger: { log: jest.fn() } })).rejects.toThrow(
+      /RETENTION_DAYS must be a number/,
+    );
+  });
+});

--- a/apps/backend/src/scripts/prune-old-data.ts
+++ b/apps/backend/src/scripts/prune-old-data.ts
@@ -1,4 +1,5 @@
 import { runCronJob } from './_bootstrap';
+import { OccupancyEventsModule } from '../occupancy-events/occupancy-events.module';
 import { OccupancyEventsService } from '../occupancy-events/occupancy-events.service';
 
 /**
@@ -28,7 +29,7 @@ function parseRetentionDays(): number {
   return parsed;
 }
 
-void runCronJob('prune-old-data', async ({ app, logger }) => {
+void runCronJob('prune-old-data', [OccupancyEventsModule], async ({ app, logger }) => {
   const retentionDays = parseRetentionDays();
   const svc = app.get(OccupancyEventsService);
   const result = await svc.pruneOldData(retentionDays);

--- a/apps/backend/src/scripts/snapshot.spec.ts
+++ b/apps/backend/src/scripts/snapshot.spec.ts
@@ -1,0 +1,34 @@
+jest.mock('./_bootstrap', () => ({ runCronJob: jest.fn() }));
+
+import { runCronJob } from './_bootstrap';
+import { OccupancyEventsModule } from '../occupancy-events/occupancy-events.module';
+import './snapshot';
+
+type WorkFn = (ctx: { app: unknown; logger: unknown }) => Promise<void>;
+
+describe('snapshot cron', () => {
+  const call = (runCronJob as jest.Mock).mock.calls[0];
+
+  it('registers under the snapshot job name with [OccupancyEventsModule]', () => {
+    expect(call[0]).toBe('snapshot');
+    expect(call[1]).toEqual([OccupancyEventsModule]);
+  });
+
+  it('calls OccupancyEventsService.createSnapshots and logs the count', async () => {
+    const work = call[2] as WorkFn;
+    const svc = {
+      createSnapshots: jest
+        .fn()
+        .mockResolvedValue({ count: 42, timestamp: '2026-05-03T00:00:00Z' }),
+    };
+    const logger = { log: jest.fn() };
+    const app = { get: jest.fn().mockReturnValue(svc) };
+
+    await work({ app, logger });
+
+    expect(svc.createSnapshots).toHaveBeenCalledTimes(1);
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('created 42 occupancy snapshots'),
+    );
+  });
+});

--- a/apps/backend/src/scripts/snapshot.ts
+++ b/apps/backend/src/scripts/snapshot.ts
@@ -1,7 +1,8 @@
 import { runCronJob } from './_bootstrap';
+import { OccupancyEventsModule } from '../occupancy-events/occupancy-events.module';
 import { OccupancyEventsService } from '../occupancy-events/occupancy-events.service';
 
-void runCronJob('snapshot', async ({ app, logger }) => {
+void runCronJob('snapshot', [OccupancyEventsModule], async ({ app, logger }) => {
   const svc = app.get(OccupancyEventsService);
   const result = await svc.createSnapshots();
   logger.log(

--- a/apps/backend/src/scripts/verify-latest-backup.spec.ts
+++ b/apps/backend/src/scripts/verify-latest-backup.spec.ts
@@ -1,0 +1,148 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough, Readable } from 'node:stream';
+import { setImmediate } from 'node:timers';
+import { gzipSync } from 'node:zlib';
+
+jest.mock('./_bootstrap', () => ({ runCronJob: jest.fn() }));
+
+// A tiny but VALID gzip payload — empty Readables crash the gunzip pipeline
+// with Z_BUF_ERROR before pg_restore's exit handler can resolve.
+const VALID_GZIP_CHUNK = gzipSync(Buffer.from('PGDMP-fake-toc'));
+
+const mockSend = jest.fn();
+const MockS3Ctor = jest.fn().mockImplementation(() => ({ send: mockSend }));
+const MockListCmd = jest.fn().mockImplementation((input) => ({ __cmd: 'list', input }));
+const MockGetCmd = jest.fn().mockImplementation((input) => ({ __cmd: 'get', input }));
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: MockS3Ctor,
+  ListObjectsV2Command: MockListCmd,
+  GetObjectCommand: MockGetCmd,
+}));
+
+const mockSpawn = jest.fn();
+jest.mock('node:child_process', () => ({ spawn: mockSpawn }));
+
+import { runCronJob } from './_bootstrap';
+import './verify-latest-backup';
+
+type WorkFn = (ctx: { logger: { log: jest.Mock } }) => Promise<void>;
+
+const REQUIRED_ENV = {
+  R2_ACCOUNT_ID: 'acct',
+  R2_ACCESS_KEY_ID: 'ak',
+  R2_SECRET_ACCESS_KEY: 'sk',
+  R2_BACKUPS_BUCKET: 'bucket',
+};
+
+function setEnv(env: Record<string, string | undefined>) {
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+function makePgRestore(exitCode = 0, listingLines = 100) {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: Readable;
+    stderr: Readable;
+    stdin: PassThrough;
+  };
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
+  proc.stdin = new PassThrough();
+  setImmediate(() => {
+    if (listingLines > 0) {
+      (proc.stdout as PassThrough).write('a\n'.repeat(listingLines));
+    }
+    (proc.stdout as PassThrough).end();
+    // Drain stdin so the upstream pipe doesn't hang
+    proc.stdin.resume();
+    proc.emit('exit', exitCode);
+  });
+  return proc;
+}
+
+describe('verify-latest-backup cron', () => {
+  const call = (runCronJob as jest.Mock).mock.calls[0];
+  const work = call[2] as WorkFn;
+  const original = { ...process.env };
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    mockSend.mockReset();
+    MockS3Ctor.mockClear();
+    MockListCmd.mockClear();
+    MockGetCmd.mockClear();
+    setEnv(REQUIRED_ENV);
+  });
+
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  it('registers as verify-latest-backup with no extra feature modules', () => {
+    expect(call[0]).toBe('verify-latest-backup');
+    expect(call[1]).toEqual([]);
+  });
+
+  it.each(Object.keys(REQUIRED_ENV))('throws when %s is missing', async (key) => {
+    setEnv({ [key]: undefined });
+    await expect(work({ logger: { log: jest.fn() } })).rejects.toThrow(/missing/);
+  });
+
+  it('throws when the bucket is empty', async () => {
+    mockSend.mockResolvedValueOnce({ Contents: [] });
+    await expect(work({ logger: { log: jest.fn() } })).rejects.toThrow(
+      /no objects under r2:/,
+    );
+  });
+
+  it('throws when the newest backup is older than the staleness threshold', async () => {
+    const stale = new Date(Date.now() - 30 * 3600 * 1000); // 30h ago, > 26h
+    mockSend.mockResolvedValueOnce({
+      Contents: [{ Key: 'daily/old.dump.gz', LastModified: stale, Size: 1 }],
+    });
+    await expect(work({ logger: { log: jest.fn() } })).rejects.toThrow(
+      /is .* old \(>26h\)/,
+    );
+  });
+
+  it('downloads the newest backup and runs pg_restore --list', async () => {
+    const fresh = new Date(Date.now() - 60 * 60 * 1000); // 1h ago
+    mockSend
+      .mockResolvedValueOnce({
+        Contents: [
+          { Key: 'daily/older.dump.gz', LastModified: new Date(0), Size: 1 },
+          { Key: 'daily/newer.dump.gz', LastModified: fresh, Size: 4096 },
+        ],
+      })
+      .mockResolvedValueOnce({ Body: Readable.from([VALID_GZIP_CHUNK]) });
+
+    mockSpawn.mockReturnValue(makePgRestore(0, 50));
+    const logger = { log: jest.fn() };
+
+    await work({ logger });
+
+    expect(MockGetCmd).toHaveBeenCalledWith(
+      expect.objectContaining({ Key: 'daily/newer.dump.gz' }),
+    );
+    expect(mockSpawn).toHaveBeenCalledWith('pg_restore', ['--list'], expect.any(Object));
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('OK — daily/newer.dump.gz parsed cleanly'),
+    );
+  });
+
+  it('throws when pg_restore --list exits non-zero', async () => {
+    const fresh = new Date(Date.now() - 60 * 60 * 1000);
+    mockSend
+      .mockResolvedValueOnce({
+        Contents: [{ Key: 'daily/x.dump.gz', LastModified: fresh, Size: 1 }],
+      })
+      .mockResolvedValueOnce({ Body: Readable.from([VALID_GZIP_CHUNK]) });
+    mockSpawn.mockReturnValue(makePgRestore(2, 0));
+
+    await expect(work({ logger: { log: jest.fn() } })).rejects.toThrow(
+      /pg_restore --list exited 2/,
+    );
+  });
+});

--- a/apps/backend/src/scripts/verify-latest-backup.ts
+++ b/apps/backend/src/scripts/verify-latest-backup.ts
@@ -22,7 +22,7 @@ import { runCronJob } from './_bootstrap';
  */
 const STALENESS_HOURS = 26; // backup runs every 24h; 2h grace
 
-void runCronJob('verify-latest-backup', async ({ logger }) => {
+void runCronJob('verify-latest-backup', [], async ({ logger }) => {
   const accountId = process.env.R2_ACCOUNT_ID;
   const accessKeyId = process.env.R2_ACCESS_KEY_ID;
   const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;

--- a/apps/backend/src/shuttle-tracker/shuttle-tracker-core.module.ts
+++ b/apps/backend/src/shuttle-tracker/shuttle-tracker-core.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { ShuttleTrackerService } from './shuttle-tracker.service';
+
+/**
+ * Lightweight shuttle-tracker module exposing only `ShuttleTrackerService`
+ * (REST fetches against PassioGo + Redis read/write).
+ *
+ * Use this from cron scripts (`fetch-transit.ts`) so they don't pull in
+ * `PassioWebSocketService` (opens a `wss://passio3.com/` connection in
+ * onModuleInit) or `ShuttleTrackerGateway` (Socket.IO server) — both of
+ * those only make sense inside the long-lived `app` Fly process.
+ *
+ * The full {@link ShuttleTrackerModule} re-exports this so HTTP/WS consumers
+ * still get the same service instance via DI.
+ */
+@Module({
+  providers: [ShuttleTrackerService],
+  exports: [ShuttleTrackerService],
+})
+export class ShuttleTrackerCoreModule {}

--- a/apps/backend/src/shuttle-tracker/shuttle-tracker.module.ts
+++ b/apps/backend/src/shuttle-tracker/shuttle-tracker.module.ts
@@ -1,16 +1,25 @@
 import { Module } from '@nestjs/common';
 import { ShuttleTrackerController } from './shuttle-tracker.controller';
+import { ShuttleTrackerCoreModule } from './shuttle-tracker-core.module';
 import { ShuttleTrackerService } from './shuttle-tracker.service';
 import { PassioWebSocketService } from './passio-websocket.service';
 import { ShuttleTrackerGateway } from './shuttle-tracker.gateway';
 
+/**
+ * Full shuttle-tracker module for the long-lived `app` process: serves the
+ * REST controller, runs the Socket.IO gateway, and keeps a persistent
+ * WebSocket open to PassioGo for live shuttle positions.
+ *
+ * Cron scripts should import {@link ShuttleTrackerCoreModule} instead — it
+ * exposes `ShuttleTrackerService` without the WebSocket/Gateway bootstrap.
+ */
 @Module({
+  imports: [ShuttleTrackerCoreModule],
   controllers: [ShuttleTrackerController],
   providers: [
-    ShuttleTrackerService,
     PassioWebSocketService,
-    ShuttleTrackerGateway
+    ShuttleTrackerGateway,
   ],
-  exports: [ShuttleTrackerService], 
+  exports: [ShuttleTrackerService],
 })
 export class ShuttleTrackerModule {}

--- a/apps/backend/src/shuttle-tracker/shuttle-tracker.module.ts
+++ b/apps/backend/src/shuttle-tracker/shuttle-tracker.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ShuttleTrackerController } from './shuttle-tracker.controller';
 import { ShuttleTrackerCoreModule } from './shuttle-tracker-core.module';
-import { ShuttleTrackerService } from './shuttle-tracker.service';
 import { PassioWebSocketService } from './passio-websocket.service';
 import { ShuttleTrackerGateway } from './shuttle-tracker.gateway';
 
@@ -20,6 +19,6 @@ import { ShuttleTrackerGateway } from './shuttle-tracker.gateway';
     PassioWebSocketService,
     ShuttleTrackerGateway,
   ],
-  exports: [ShuttleTrackerService],
+  exports: [ShuttleTrackerCoreModule],
 })
 export class ShuttleTrackerModule {}


### PR DESCRIPTION
## Why

Production incident **2026-05-03 14:00–14:15Z**: at the top of the hour 5 `*/15` cron jobs (snapshot + 4 `notify-*` triggers) spawned simultaneously on the 1 GB cron VM. Each script bootstraps the **full `AppModule`** (~180 MB RSS — pulls in `PassioGoModule` WebSocket + `NotificationsModule` Firebase Admin + every other module even though e.g. `snapshot.js` only needs Prisma + a couple services), so 5 × 180 MB > 1 GB → supercronic children OOM-killed each other (`exit 137`), which left zombie pg-pool connections and caused `Connection terminated due to connection timeout` errors on survivors inside `withAdvisoryLock`.

Also caught a few unrelated Sentry-quality issues in the same logs: cold-start `App not listening on port 3000` from Fly Doctor, `Called end on pool more than once` on shutdown, and the issue feed being flooded by 404s from internet scanners (`/elanpaymentsolutions`, `/wp-login.php`, etc.).

## What

### Infra hot-fix — `apps/backend/fly.toml`
- **cron VM memory `1024mb` → `2048mb`.** Headroom for concurrent bootstraps while the long-term per-script module split rolls out.
- **`/health/live` `grace_period` `10s` → `30s`.** Cold start with `min_machines_running = 0` is ~10–15s end-to-end (Fly boot + Nest module graph + Prisma → Neon connect), tripping Fly Doctor's "App not listening on port 3000" alert before bootstrap finished.

### Long-term fix — per-script Nest modules
Cron scripts no longer bootstrap `AppModule`. Introduced `runCronJob(name, modules, fn)` (`apps/backend/src/scripts/_bootstrap.ts`) and a feature-flag `CronAppModule.withFeatures([...])` so each script declares only the modules it needs:
- `snapshot.js`, `cleanup-device-states.js`, `prune-old-data.js`, `backup-db.js`, `verify-latest-backup.js` — Prisma only.
- `fetch-weather.js`, `fetch-weather-forecast.js` — Prisma + `WeatherModule`.
- `fetch-transit.js` — Prisma + new `ShuttleTrackerCoreModule` (lightweight; no Passio WebSocket / gateway).
- `notify-*.js` — Prisma + `NotificationsModule`.

Split `ShuttleTrackerModule` into `ShuttleTrackerCoreModule` (just `ShuttleTrackerService`) and the full `ShuttleTrackerModule` (controller + WebSocket gateway + Passio client). The full module re-exports the core module so AppModule consumers are unaffected.

Per-script RSS dropped from ~180 MB → ~40–90 MB depending on feature set. The 2 GB cron VM bump in `fly.toml` is now a safety margin, not a requirement.

### `apps/backend/src/common/filters/all-exceptions.filter.ts`
- Stop reporting HTTP 4xx to Sentry. Replaced `@SentryExceptionCaptured()` with explicit `Sentry.captureException` only when `status >= 500` (or non-`HttpException`). 4xx now logs at `warn` level **without a stack trace** — almost always user input mistakes or scanners hitting non-existent paths.

### `apps/backend/src/database/database.module.ts`
- `pg.Pool` `connectionTimeoutMillis` `5s` → `15s` for both write and read pools. Neon serverless compute can take 5–10s to resume from suspend; 5s caused `Connection terminated due to connection timeout` inside `withAdvisoryLock` for cron jobs against a cold compute.
- `PrismaService.onModuleDestroy` is now idempotent via a `destroyed` flag. `pg.Pool` throws `Called end on pool more than once` when Nest's global shutdown hook and an explicit `app.close()` both fire (`SHARKPARK-BACKEND-3`).

### Tests (+57)
New unit coverage for `AllExceptionsFilter`, `_bootstrap` (`runCronJob` lifecycle, advisory-lock wrap, error → exit 1, signal handling), the 5 simple cron entry scripts, `fetch-transit`, `backup-db`, and `verify-latest-backup`. Total backend unit suite: **626 passed**.

## Verification

- `pnpm -C apps/backend test` — 626 passed.
- `pnpm -C apps/backend test:e2e` — 10 suites green (after the `ShuttleTrackerCoreModule` re-export fix in `e2ade88`).
- `pnpm typecheck` + `pnpm lint` — clean across all 5 workspaces.
- `npx jest src/scripts/_cron-monitors.spec.ts` — crontab/monitor parity preserved.
- Prisma 7.8.0 resolves cleanly; the older `Cannot find module '.prisma/client/default'` (`SHARKPARK-BACKEND-1`) was on 7.4.0 and should auto-resolve on deploy.

## Follow-up (separate PR, after #152 merges)

PR #152 (campus-event scraper) introduces the `CampusEvent` table that `notify-events.js` (added here) reads from. The crontab entry will be a no-op in prod until #152 lands. Order:

1. Merge **this PR (#176)** first — fixes the live OOM/Sentry incident, doesn't depend on #152.
2. Merge **#152** — rebased on top of this branch's cron refactor.
3. Follow-up PR for the second-site scraper, building on #152's scraper abstraction and tightening the `notify-events` cron wiring (e.g. dropping cadence to match scrape frequency once we know it).
