### PR TITLE
chore(fly): keep one app machine warm (min_machines_running = 1)

### DIFF
--- a/apps/backend/fly.toml
+++ b/apps/backend/fly.toml
@@ -1,7 +1,7 @@
 # fly.toml — sharkpark-api (https://fly.io/apps/sharkpark-api)
 #
 # Two process groups, one image:
-#   app  — Nest HTTP server, autostop enabled (min=0)
+#   app  — Nest HTTP server, autostop enabled (min=1, keeps one warm)
 #   cron — supercronic running apps/backend/cron/crontab on a tiny
 #          always-on VM. Fly's --schedule only supports hourly/daily/
 #          weekly/monthly, so supercronic gives us proper cron granularity.
@@ -40,11 +40,15 @@ primary_region = 'lax'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  # min=0 saves ~$5/mo but adds ~10s cold-start to the first request after
-  # idle (measured 2026-04-26: 10.7s TTFB; warm p95 ~0.28s). Breakdown:
-  # Fly boot + Node/Nest start + Prisma->Neon cold connect. Bump to 1 if
-  # mobile users complain about latency. See docs/runbooks/runbook.md.
-  min_machines_running = 0
+  # Keep one machine warm at all times. min=0 saves ~$1–2/mo but the ~10s
+  # cold start on the first request after idle (measured 2026-04-26:
+  # 10.7s TTFB; warm p95 ~0.28s — Fly boot + Node/Nest start + Prisma->Neon
+  # cold connect) was unacceptable for the mobile UX (no loading skeleton
+  # plausibly hides 10s) and was generating false-positive Better Stack
+  # alerts (PR03/PM05 502s when the uptime probe was the request that woke
+  # the machine). With min=1 the second machine still autostops after idle
+  # so we don't pay double during low traffic. See docs/runbooks/runbook.md.
+  min_machines_running = 1
   processes = ['app']
 
   [http_service.concurrency]

--- a/apps/backend/fly.toml
+++ b/apps/backend/fly.toml
@@ -59,11 +59,13 @@ primary_region = 'lax'
   [[http_service.checks]]
     interval = '15s'
     timeout = '2s'
-    # Cold start (min_machines_running = 0) takes ~10-15s end-to-end:
-    # Fly boot + Node + Nest module graph + Prisma connect to Neon. A 10s
-    # grace tripped Fly Doctor's "App not listening on port 3000" alert
-    # because the live probe fired before bootstrap finished. Match the
-    # ready check (30s) so cold starts don't false-alarm.
+    # grace_period applies on machine boot only (deploys, crash recovery,
+    # scale-up of the second machine — not steady-state requests, since
+    # min_machines_running = 1 keeps one warm). Boot is ~10-15s end-to-end
+    # (Fly boot + Node + Nest module graph + Prisma connect to Neon); a
+    # 10s grace previously tripped Fly Doctor's "App not listening on port
+    # 3000" alert because the live probe fired before bootstrap finished.
+    # 30s gives headroom and matches the ready check below.
     grace_period = '30s'
     method = 'GET'
     path = '/api/v1/health/live'
@@ -72,6 +74,8 @@ primary_region = 'lax'
   [[http_service.checks]]
     interval = '30s'
     timeout = '5s'
+    # See note on the live check above — 30s covers cold boot during
+    # deploys / crash recovery, not steady-state.
     grace_period = '30s'
     method = 'GET'
     path = '/api/v1/health/ready'


### PR DESCRIPTION
## Why

Follow-up to #176. The cron OOM/Sentry fixes landed, but the app process group is still running with `min_machines_running = 0`, which has two ongoing problems:

1. **Cold-start UX is bad.** First request after idle takes ~10s end-to-end (Fly boot + Nest module graph + Prisma → Neon resume; measured 2026-04-26 at 10.7s TTFB vs warm p95 ~280ms). On mobile, no loading state plausibly hides 10s of waiting for parking-lot data.
2. **Better Stack false alerts.** When the uptime probe is itself the request that wakes the machine, Fly proxy returns PR03/PM05 502s after retrying for 8s, which Better Stack reports as a full outage that "recovers" on the next check. Saw one such false page today (2026-05-03 06:10 PT).

## What

- `min_machines_running = 0` → `1` for the `app` process group in `apps/backend/fly.toml`.
- Updated the inline comment + the file-header comment to reflect the new policy.

The `cron` process group is unaffected — it stays on its own VM with its own scaling rules.

## Cost

~$1–2/mo on `shared-cpu-1x` (and we may already be inside Fly's free allowance depending on month-to-date usage). The second machine still autostops during quiet periods, so we don't pay double under typical load.

## Verification

- Local: `grep min_machines_running apps/backend/fly.toml` → `min_machines_running = 1`.
- Post-deploy: `fly status -a sharkpark-api` should show 1 app machine `started` continuously, even after sustained idle. Better Stack should stop emitting cold-start false positives.

## Related

- Closes the cold-start follow-up note in the runbook.
- Pairs with a Better Stack monitor change (Confirmation period: Immediate → 1 minute) made out-of-band in the Better Stack dashboard.
