### PR TITLE
test(services): add 34 tests for users, carBluetooth, contributor

### DIFF
--- a/apps/mobile/__tests__/carBluetooth.test.ts
+++ b/apps/mobile/__tests__/carBluetooth.test.ts
@@ -6,7 +6,7 @@
  * every API returns a benign value instead of crashing.
  */
 
-import { NativeModules } from 'react-native';
+import { NativeModules, NativeEventEmitter } from 'react-native';
 
 // NativeEventEmitter is mocked globally by the RN Jest preset.
 // Provide a per-test factory for NativeModules.CarBluetoothModule.
@@ -14,8 +14,25 @@ import { NativeModules } from 'react-native';
 // We import the module under test AFTER configuring NativeModules so
 // the module-level `isAvailable` getter reads the right value.
 
+// Snapshot the original NativeModules.CarBluetoothModule (almost always
+// undefined in the Jest env) and the original NativeEventEmitter prototype
+// addListener so we can restore them between tests. Without restoration,
+// NativeModules is a process-wide singleton and `.prototype` mutations leak
+// into every other suite that runs after this one — ordering bugs that are
+// brutal to debug. (Flagged by Copilot review on PR #179.)
+const originalCarBluetoothModule = NativeModules.CarBluetoothModule;
+const originalAddListener = NativeEventEmitter.prototype.addListener;
+
 describe('carBluetooth service', () => {
   afterEach(() => {
+    // Restore native module
+    if (originalCarBluetoothModule === undefined) {
+      delete NativeModules.CarBluetoothModule;
+    } else {
+      NativeModules.CarBluetoothModule = originalCarBluetoothModule;
+    }
+    // Restore prototype mutation from the addListener tests below
+    NativeEventEmitter.prototype.addListener = originalAddListener;
     jest.resetModules();
     jest.clearAllMocks();
   });
@@ -90,9 +107,7 @@ describe('carBluetooth service', () => {
       // Provide the module so NativeEventEmitter can be constructed around it
       withNativeModule({ addListener: jest.fn(), removeListeners: jest.fn() });
 
-      // Patch NativeEventEmitter prototype after module reset
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const NativeEventEmitter = require('react-native').NativeEventEmitter;
+      // Patch the same NativeEventEmitter the SUT will see (afterEach restores).
       NativeEventEmitter.prototype.addListener = mockAddListener;
 
       const svc = loadService();
@@ -121,8 +136,6 @@ describe('carBluetooth service', () => {
       const mockAddListener = jest.fn().mockReturnValue({ remove: mockRemove });
       withNativeModule({ addListener: jest.fn(), removeListeners: jest.fn() });
 
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const NativeEventEmitter = require('react-native').NativeEventEmitter;
       NativeEventEmitter.prototype.addListener = mockAddListener;
 
       const svc = loadService();

--- a/apps/mobile/__tests__/carBluetooth.test.ts
+++ b/apps/mobile/__tests__/carBluetooth.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for src/services/carBluetooth.ts
+ *
+ * The service wraps NativeModules.CarBluetoothModule. All tests confirm the
+ * safe-fallback contract: when the native module is absent (Android/sim)
+ * every API returns a benign value instead of crashing.
+ */
+
+import { NativeModules } from 'react-native';
+
+// NativeEventEmitter is mocked globally by the RN Jest preset.
+// Provide a per-test factory for NativeModules.CarBluetoothModule.
+
+// We import the module under test AFTER configuring NativeModules so
+// the module-level `isAvailable` getter reads the right value.
+
+describe('carBluetooth service', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  function loadService() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return (require('../src/services/carBluetooth') as { default: typeof import('../src/services/carBluetooth').default }).default;
+  }
+
+  function withNativeModule(impl: Record<string, unknown> | null) {
+    if (impl) {
+      NativeModules.CarBluetoothModule = impl;
+    } else {
+      delete NativeModules.CarBluetoothModule;
+    }
+  }
+
+  // ── isAvailable ────────────────────────────────────────────────────────────
+
+  describe('isAvailable', () => {
+    it('is false when the native module is absent', () => {
+      withNativeModule(null);
+      const svc = loadService();
+      expect(svc.isAvailable).toBe(false);
+    });
+
+    it('is true when the native module is present', () => {
+      withNativeModule({ isConnected: jest.fn(), onConnect: jest.fn(), onDisconnect: jest.fn() });
+      const svc = loadService();
+      expect(svc.isAvailable).toBe(true);
+    });
+  });
+
+  // ── isConnected ────────────────────────────────────────────────────────────
+
+  describe('isConnected', () => {
+    it('returns false when native module is absent', async () => {
+      withNativeModule(null);
+      const svc = loadService();
+      await expect(svc.isConnected()).resolves.toBe(false);
+    });
+
+    it('returns the value from the native module', async () => {
+      withNativeModule({ isConnected: jest.fn().mockResolvedValue(true) });
+      const svc = loadService();
+      await expect(svc.isConnected()).resolves.toBe(true);
+    });
+
+    it('returns false when the native module throws', async () => {
+      withNativeModule({ isConnected: jest.fn().mockRejectedValue(new Error('BT error')) });
+      const svc = loadService();
+      await expect(svc.isConnected()).resolves.toBe(false);
+    });
+  });
+
+  // ── onConnect ─────────────────────────────────────────────────────────────
+
+  describe('onConnect', () => {
+    it('returns a no-op remove handle when native module is absent', () => {
+      withNativeModule(null);
+      const svc = loadService();
+      const handle = svc.onConnect(jest.fn());
+      expect(handle).toHaveProperty('remove');
+      expect(() => handle.remove()).not.toThrow();
+    });
+
+    it('calls NativeEventEmitter.addListener and wires remove', () => {
+      const mockRemove = jest.fn();
+      const mockAddListener = jest.fn().mockReturnValue({ remove: mockRemove });
+      // Provide the module so NativeEventEmitter can be constructed around it
+      withNativeModule({ addListener: jest.fn(), removeListeners: jest.fn() });
+
+      // Patch NativeEventEmitter prototype after module reset
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const NativeEventEmitter = require('react-native').NativeEventEmitter;
+      NativeEventEmitter.prototype.addListener = mockAddListener;
+
+      const svc = loadService();
+      const listener = jest.fn();
+      const handle = svc.onConnect(listener);
+
+      expect(mockAddListener).toHaveBeenCalledWith('onCarBluetoothConnect', listener);
+      handle.remove();
+      expect(mockRemove).toHaveBeenCalled();
+    });
+  });
+
+  // ── onDisconnect ───────────────────────────────────────────────────────────
+
+  describe('onDisconnect', () => {
+    it('returns a no-op remove handle when native module is absent', () => {
+      withNativeModule(null);
+      const svc = loadService();
+      const handle = svc.onDisconnect(jest.fn());
+      expect(handle).toHaveProperty('remove');
+      expect(() => handle.remove()).not.toThrow();
+    });
+
+    it('calls NativeEventEmitter.addListener and wires remove', () => {
+      const mockRemove = jest.fn();
+      const mockAddListener = jest.fn().mockReturnValue({ remove: mockRemove });
+      withNativeModule({ addListener: jest.fn(), removeListeners: jest.fn() });
+
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const NativeEventEmitter = require('react-native').NativeEventEmitter;
+      NativeEventEmitter.prototype.addListener = mockAddListener;
+
+      const svc = loadService();
+      const listener = jest.fn();
+      const handle = svc.onDisconnect(listener);
+
+      expect(mockAddListener).toHaveBeenCalledWith('onCarBluetoothDisconnect', listener);
+      handle.remove();
+      expect(mockRemove).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/mobile/__tests__/contributor.service.test.ts
+++ b/apps/mobile/__tests__/contributor.service.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for src/services/api/contributor.ts
+ *
+ * Covers:
+ *   - getContributorStateSync  — synchronous state snapshot
+ *   - subscribeContributorState — pub/sub contract (add / remove listener)
+ *   - registerContributorGrant  — dedup, in-flight sharing, POST, optimistic + definitive emit
+ *   - revokeContributorGrant   — resets dedup state, emits revoked, POST
+ *   - refreshLotsForPermissionChange — always emits, accepts custom state
+ *   - __resetContributorGrantStateForTests — test helper works
+ */
+
+import { apiService } from '../src/services/api/base';
+import { cacheService } from '../src/services/api/cache';
+import { renderHook, act } from '@testing-library/react-native';
+
+jest.mock('../src/services/api/base');
+jest.mock('../src/services/api/cache');
+
+const mockApiService = apiService as jest.Mocked<typeof apiService>;
+const mockCacheService = cacheService as jest.Mocked<typeof cacheService>;
+
+import {
+  getContributorStateSync,
+  subscribeContributorState,
+  registerContributorGrant,
+  revokeContributorGrant,
+  refreshLotsForPermissionChange,
+  __resetContributorGrantStateForTests,
+  useContributorState,
+} from '../src/services/api/contributor';
+
+describe('contributor service', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    __resetContributorGrantStateForTests();
+    // cacheService.invalidatePrefix is called by emitContributorState; resolve immediately
+    mockCacheService.invalidatePrefix.mockResolvedValue(undefined);
+    // __reset clears inFlight/lastGrantAt/listeners but not currentState.
+    // Drive it back to 'granted' (the canonical initial value) so tests
+    // that revokeContributorGrant in a prior case don't bleed state.
+    await refreshLotsForPermissionChange('granted');
+    // clear call counts AFTER the reset emit so mock counts start at 0
+    jest.clearAllMocks();
+    mockCacheService.invalidatePrefix.mockResolvedValue(undefined);
+  });
+
+  // ── getContributorStateSync ────────────────────────────────────────────────
+
+  describe('getContributorStateSync', () => {
+    it('returns the initial state "granted"', () => {
+      expect(getContributorStateSync()).toBe('granted');
+    });
+
+    it('reflects state after revokeContributorGrant', async () => {
+      mockApiService.post.mockResolvedValue({ success: true, data: undefined });
+      await revokeContributorGrant();
+      expect(getContributorStateSync()).toBe('revoked');
+    });
+  });
+
+  // ── subscribeContributorState ──────────────────────────────────────────────
+
+  describe('subscribeContributorState', () => {
+    it('calls the listener when state is emitted via revokeContributorGrant', async () => {
+      const listener = jest.fn();
+      subscribeContributorState(listener);
+      mockApiService.post.mockResolvedValue({ success: true, data: undefined });
+
+      await revokeContributorGrant();
+
+      expect(listener).toHaveBeenCalledWith('revoked');
+    });
+
+    it('stops calling the listener after unsubscribe', async () => {
+      const listener = jest.fn();
+      const unsubscribe = subscribeContributorState(listener);
+      unsubscribe();
+
+      mockApiService.post.mockResolvedValue({ success: true, data: undefined });
+      await revokeContributorGrant();
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('multiple listeners all receive the event', async () => {
+      const a = jest.fn();
+      const b = jest.fn();
+      subscribeContributorState(a);
+      subscribeContributorState(b);
+
+      mockApiService.post.mockResolvedValue({ success: true, data: undefined });
+      await revokeContributorGrant();
+
+      expect(a).toHaveBeenCalledWith('revoked');
+      expect(b).toHaveBeenCalledWith('revoked');
+    });
+  });
+
+  // ── registerContributorGrant ───────────────────────────────────────────────
+
+  describe('registerContributorGrant', () => {
+    it('POSTs to the contributor grant endpoint', async () => {
+      mockApiService.post.mockResolvedValue({ success: true, data: undefined });
+      await registerContributorGrant();
+      expect(mockApiService.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits "granted" to listeners', async () => {
+      const listener = jest.fn();
+      subscribeContributorState(listener);
+      mockApiService.post.mockResolvedValue({ success: true, data: undefined });
+
+      await registerContributorGrant();
+
+      expect(listener).toHaveBeenCalledWith('granted');
+    });
+
+    it('dedupes back-to-back calls within MIN_REFRESH_MS', async () => {
+      mockApiService.post.mockResolvedValue({ success: true, data: undefined });
+      await registerContributorGrant();
+      await registerContributorGrant(); // should no-op
+
+      expect(mockApiService.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('force=true bypasses the dedup window', async () => {
+      mockApiService.post.mockResolvedValue({ success: true, data: undefined });
+      await registerContributorGrant();
+      await registerContributorGrant({ force: true }); // should bypass dedup
+
+      expect(mockApiService.post).toHaveBeenCalledTimes(2);
+    });
+
+    it('is best-effort: does not throw on POST failure', async () => {
+      mockApiService.post.mockRejectedValue(new Error('server down'));
+      await expect(registerContributorGrant()).resolves.toBeUndefined();
+    });
+
+    it('state is still "granted" after a failed POST (optimistic emit succeeded)', async () => {
+      mockApiService.post.mockRejectedValue(new Error('server down'));
+      await registerContributorGrant();
+      expect(getContributorStateSync()).toBe('granted');
+    });
+  });
+
+  // ── revokeContributorGrant ────────────────────────────────────────────────
+
+  describe('revokeContributorGrant', () => {
+    it('emits "revoked" before the POST', async () => {
+      const events: string[] = [];
+      subscribeContributorState(s => events.push(s));
+      mockApiService.post.mockResolvedValue({ success: true, data: undefined });
+
+      await revokeContributorGrant();
+
+      expect(events[0]).toBe('revoked');
+    });
+
+    it('sets state to "revoked"', async () => {
+      mockApiService.post.mockResolvedValue({ success: true, data: undefined });
+      await revokeContributorGrant();
+      expect(getContributorStateSync()).toBe('revoked');
+    });
+
+    it('is best-effort: does not throw on POST failure', async () => {
+      mockApiService.post.mockRejectedValue(new Error('network error'));
+      await expect(revokeContributorGrant()).resolves.toBeUndefined();
+    });
+
+    it('resets dedup so a subsequent grant goes through', async () => {
+      mockApiService.post.mockResolvedValue({ success: true, data: undefined });
+      // First grant sets lastGrantAt
+      await registerContributorGrant();
+      // Revoke resets lastGrantAt to 0
+      await revokeContributorGrant();
+      // Second grant should POST (not deduped)
+      await registerContributorGrant();
+
+      // 3 POSTs total: grant + revoke + grant
+      expect(mockApiService.post).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  // ── refreshLotsForPermissionChange ────────────────────────────────────────
+
+  describe('refreshLotsForPermissionChange', () => {
+    it('defaults to "revoked" and emits it', async () => {
+      const listener = jest.fn();
+      subscribeContributorState(listener);
+
+      await refreshLotsForPermissionChange();
+
+      expect(listener).toHaveBeenCalledWith('revoked');
+      expect(getContributorStateSync()).toBe('revoked');
+    });
+
+    it('accepts an explicit state', async () => {
+      const listener = jest.fn();
+      subscribeContributorState(listener);
+
+      await refreshLotsForPermissionChange('granted');
+
+      expect(listener).toHaveBeenCalledWith('granted');
+    });
+
+    it('always invalidates the lots: cache prefix', async () => {
+      await refreshLotsForPermissionChange();
+      expect(mockCacheService.invalidatePrefix).toHaveBeenCalledWith('lots:');
+    });
+  });
+
+  // ── useContributorState (hook) ────────────────────────────────────────────
+
+  describe('useContributorState', () => {
+    it('returns the current state synchronously on first render', () => {
+      const { result } = renderHook(() => useContributorState());
+      expect(result.current).toBe('granted');
+    });
+
+    it('re-renders with new state when contributor state changes', async () => {
+      mockApiService.post.mockResolvedValue({ success: true, data: undefined });
+
+      const { result } = renderHook(() => useContributorState());
+      expect(result.current).toBe('granted');
+
+      await act(async () => {
+        await revokeContributorGrant();
+      });
+
+      expect(result.current).toBe('revoked');
+    });
+  });
+
+  // ── emitContributorState: listener-throw safety ───────────────────────────
+
+  describe('emitContributorState error handling', () => {
+    it('continues notifying remaining listeners even if one throws', async () => {
+      const throwingListener = jest.fn(() => { throw new Error('listener error'); });
+      const goodListener = jest.fn();
+      subscribeContributorState(throwingListener);
+      subscribeContributorState(goodListener);
+
+      mockApiService.post.mockResolvedValue({ success: true, data: undefined });
+      await revokeContributorGrant();
+
+      expect(throwingListener).toHaveBeenCalled();
+      expect(goodListener).toHaveBeenCalledWith('revoked');
+    });
+  });
+
+  // ── registerContributorGrant: in-flight dedup ─────────────────────────────
+
+  describe('registerContributorGrant in-flight sharing', () => {
+    it('concurrent callers join the same in-flight promise (POST called once)', async () => {
+      let resolvePost!: () => void;
+      mockApiService.post.mockReturnValueOnce(
+        new Promise<{ success: boolean; data: undefined }>(res => { resolvePost = () => res({ success: true, data: undefined }); })
+      );
+
+      const p1 = registerContributorGrant();
+      const p2 = registerContributorGrant({ force: true }); // joins in-flight
+      resolvePost();
+      await Promise.all([p1, p2]);
+
+      expect(mockApiService.post).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/mobile/__tests__/users.service.test.ts
+++ b/apps/mobile/__tests__/users.service.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for src/services/api/users.ts
+ *
+ * Covers deleteMyAccount():
+ *   - success path: calls DELETE /users/me with the Bearer token
+ *   - no session: throws when loadAuth returns null
+ *   - propagates apiService errors to the caller
+ */
+
+import { apiService } from '../src/services/api/base';
+
+jest.mock('../src/services/api/base');
+const mockApiService = apiService as jest.Mocked<typeof apiService>;
+
+// loadAuth lives in src/auth and is imported by users.ts
+jest.mock('../src/auth', () => ({
+  loadAuth: jest.fn(),
+}));
+import { loadAuth } from '../src/auth';
+const mockLoadAuth = loadAuth as jest.MockedFunction<typeof loadAuth>;
+
+// Import after mocks are in place
+import { deleteMyAccount } from '../src/services/api/users';
+
+describe('users service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('deleteMyAccount', () => {
+    it('calls DELETE /users/me with the correct Bearer token', async () => {
+      mockLoadAuth.mockResolvedValueOnce({ idToken: 'test-id-token' } as Awaited<ReturnType<typeof loadAuth>>);
+      mockApiService.delete.mockResolvedValueOnce({ success: true, data: undefined });
+
+      await deleteMyAccount();
+
+      expect(mockApiService.delete).toHaveBeenCalledWith('/users/me', {
+        headers: { Authorization: 'Bearer test-id-token' },
+      });
+    });
+
+    it('throws when there is no authenticated session', async () => {
+      mockLoadAuth.mockResolvedValueOnce(null);
+
+      await expect(deleteMyAccount()).rejects.toThrow('No authenticated session found.');
+      expect(mockApiService.delete).not.toHaveBeenCalled();
+    });
+
+    it('propagates errors thrown by apiService.delete', async () => {
+      mockLoadAuth.mockResolvedValueOnce({ idToken: 'test-id-token' } as Awaited<ReturnType<typeof loadAuth>>);
+      const networkError = new Error('Network failure');
+      mockApiService.delete.mockRejectedValueOnce(networkError);
+
+      await expect(deleteMyAccount()).rejects.toThrow('Network failure');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Audited service-layer test coverage and added targeted tests for the three lowest-coverage files, bringing them all to 100% statements/functions/lines.

## Coverage changes

| File | Before | After (stmts) |
|------|--------|---------------|
| `src/services/api/users.ts` | 0% | **100%** |
| `src/services/carBluetooth.ts` | 0% | **100%** |
| `src/services/api/contributor.ts` | 22.8% | **100%** |

## New test files

### `__tests__/users.service.test.ts` (3 tests)
- `deleteMyAccount` success path — verifies `DELETE /users/me` is called with the correct `Bearer` token
- No authenticated session — throws before calling `apiService`
- `apiService.delete` error — propagates to the caller

### `__tests__/carBluetooth.test.ts` (9 tests)
- `isAvailable` — false when native module absent, true when present
- `isConnected` — returns `false` when absent, returns native value, catches native errors
- `onConnect` / `onDisconnect` — returns no-op `{ remove }` when absent; wires `NativeEventEmitter.addListener` and `remove` when present

### `__tests__/contributor.service.test.ts` (22 tests)
- `getContributorStateSync` — initial state, reflects post-revoke state
- `subscribeContributorState` — add/remove/multi-listener pub-sub contract
- `registerContributorGrant` — POST, dedup within `MIN_REFRESH_MS`, `force` bypass, best-effort on failure, in-flight promise sharing
- `revokeContributorGrant` — optimistic emit before POST, dedup reset, best-effort on failure
- `refreshLotsForPermissionChange` — default `'revoked'`, explicit state, always invalidates `lots:` cache prefix
- `useContributorState` hook — correct initial value, re-renders on state change
- Listener-throw safety — remaining listeners still notified when one throws

## Notes
- Branch coverage ceiling on `contributor.ts` is **65%** — the remaining uncovered branches are all `if (__DEV__)` console guards that require a build-time define to flip; they are not reachable in the Jest environment
- All **640 tests** pass (`pnpm test` from `apps/mobile`)
- `turbo lint` and `turbo typecheck` pass clean