### PR TITLE
fix(scheduler): export WeatherFetch services + add DI smoke test

### DIFF
--- a/apps/backend/src/scheduler/scheduler.module.spec.ts
+++ b/apps/backend/src/scheduler/scheduler.module.spec.ts
@@ -1,6 +1,8 @@
 import 'reflect-metadata';
+import { Test } from '@nestjs/testing';
 import { SCHEDULE_CRON_OPTIONS } from '@nestjs/schedule/dist/schedule.constants';
 
+import { SchedulerModule } from './scheduler.module';
 import { CRON_MONITORS, CRON_TIMEZONE } from './cron-monitors';
 
 import { SnapshotJob } from './jobs/snapshot.job';
@@ -109,5 +111,29 @@ describe('Scheduler job <-> CRON_MONITORS lockstep', () => {
     );
     expect({ missing, orphaned }).toEqual({ missing: [], orphaned: [] });
     expect(new Set(decoratedNames).size).toBe(decoratedNames.length);
+  });
+});
+
+/**
+ * DI smoke test — compiles SchedulerModule via Nest's TestingModule to ensure
+ * every job class can resolve its constructor dependencies. Catches missing
+ * `exports:` on imported feature modules (e.g. WeatherModule must export
+ * WeatherFetchService for FetchWeatherJob to inject it). The previous
+ * lockstep tests above only check decorator metadata; they do NOT exercise
+ * Nest's injector, so a missing export would slip through to runtime and
+ * crash the cron VM at boot (as happened on Fly with WeatherFetchService).
+ */
+describe('SchedulerModule DI graph', () => {
+  it('compiles with all job dependencies resolvable', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [SchedulerModule],
+    }).compile();
+
+    // Verify every job provider can actually be resolved from the container.
+    for (const jobClass of ALL_JOBS) {
+      expect(moduleRef.get(jobClass)).toBeInstanceOf(jobClass);
+    }
+
+    await moduleRef.close();
   });
 });

--- a/apps/backend/src/weather/weather.module.ts
+++ b/apps/backend/src/weather/weather.module.ts
@@ -13,6 +13,6 @@ import { NwsClient } from './nws.client';
     WeatherForecastFetchService,
     NwsClient,
   ],
-  exports: [WeatherService],
+  exports: [WeatherService, WeatherFetchService, WeatherForecastFetchService],
 })
 export class WeatherModule {}


### PR DESCRIPTION
## Problem

The single-process scheduler refactor (#192) deployed to Fly and the `cron` Machine immediately crash-looped 10× before Fly gave up:

```
[Nest] ERROR [ExceptionHandler] UnknownDependenciesException [Error]: Nest can't
resolve dependencies of the FetchWeatherJob (CronRunnerService, ?). Please make
sure that the argument WeatherFetchService at index [1] is available in the
SchedulerModule module.
```

`WeatherModule` was only exporting `WeatherService`, so `FetchWeatherJob` and `FetchWeatherForecastJob` couldn't resolve `WeatherFetchService` / `WeatherForecastFetchService` when `SchedulerModule` wired them up. The HTTP `app` process was unaffected — it doesn't import `SchedulerModule`.

## Why CI didn't catch it

The existing `scheduler.module.spec.ts` lockstep test only inspected `@Cron(...)` decorator metadata — it never compiled the module via Nest's injector, so a missing export slipped through to runtime.

## Fix

1. **`apps/backend/src/weather/weather.module.ts`** — export `WeatherFetchService` and `WeatherForecastFetchService` so the scheduler can inject them.
2. **`apps/backend/src/scheduler/scheduler.module.spec.ts`** — add a DI smoke test that compiles `SchedulerModule` via `Test.createTestingModule({ imports: [SchedulerModule] }).compile()` and asserts every one of the 18 job classes is resolvable. This would have caught the bug in CI; it'll catch any future missing export the same way.

## Audit

Checked every other job's constructor deps against its owning module's `exports:` — `WeatherModule` was the only one missing exports. All 18 jobs now resolve cleanly:

| Service | Owning module | Exported? |
|---|---|---|
| `WeatherFetchService`, `WeatherForecastFetchService` | `WeatherModule` | ✅ now |
| `OccupancyEventsService` | `OccupancyEventsModule` | ✅ |
| `EventsScraperService`, `SportsEventsScraperService` | `EventsScrapersModule` | ✅ |
| `EventsService` | `EventsModule` | ✅ |
| `ShuttleTrackerService` | `ShuttleTrackerCoreModule` | ✅ |
| `NotificationsService` | `NotificationsModule` | ✅ |
| `PrismaService` | `DatabaseModule` (`@Global()`) | ✅ |

## Verification

- `SKIP_LOCAL_INFRA=1 pnpm --filter @sharkpark/backend test` → **711/711 pass** (was 710 + new DI test).
- `pnpm --filter @sharkpark/backend build` → clean.
- New DI smoke test resolves every job class from the compiled module.

## Deploy

After merge, `fly deploy -a sharkpark-api` should bring the cron Machine up cleanly.