### PR TITLE
feat(backend): penetration-corrected utilization in analytics endpoints

### DIFF
--- a/apps/backend/src/lots/interfaces/parking-lot.interface.ts
+++ b/apps/backend/src/lots/interfaces/parking-lot.interface.ts
@@ -99,9 +99,25 @@ export interface LotRecommendation extends ParkingLotResponse {
 export interface TrendPoint {
   /** ISO 8601 datetime truncated to the hour */
   hour: string;
+  /**
+   * Average raw `occupancy_rate` (device count / capacity) over the bucket.
+   * This is a device-coverage signal, NOT true lot fullness — it understates
+   * occupancy whenever penetration < 100%. Prefer `avg_estimated_rate` when
+   * measuring actual utilization.
+   */
   avg_occupancy_rate: number;
   avg_occupancy: number;
   avg_available: number;
+  /**
+   * Average penetration-corrected fullness (`estimated_occupancy / capacity`)
+   * over the bucket — a better proxy for actual lot occupancy than the raw
+   * device rate, since each snapshot's `estimated_occupancy` was scaled by
+   * the live penetration rate at write time. `null` when no snapshot in the
+   * bucket carried an estimate (rows written before the penetration rollout).
+   */
+  avg_estimated_rate: number | null;
+  /** Average `estimated_occupancy` (vehicles, not devices) over the bucket. */
+  avg_estimated_occupancy: number | null;
   sample_count: number;
 }
 
@@ -110,7 +126,18 @@ export interface LotUtilization {
   display_name: string;
   lot_type: string;
   capacity: number;
-  /** Average occupancy_rate over the range; null when no snapshots exist */
+  /**
+   * Average raw `occupancy_rate` over the range; `null` when no snapshots
+   * exist. Device-coverage signal — see `avg_estimated_utilization` for true
+   * fullness.
+   */
   avg_utilization: number | null;
+  /**
+   * Average penetration-corrected utilization
+   * (`estimated_occupancy / capacity`) over the range. Prefer this over
+   * `avg_utilization` when ranking lots by actual fullness. `null` when no
+   * snapshot in the range carried an estimate.
+   */
+  avg_estimated_utilization: number | null;
   snapshot_count: number;
 }

--- a/apps/backend/src/lots/lots.controller.spec.ts
+++ b/apps/backend/src/lots/lots.controller.spec.ts
@@ -257,6 +257,8 @@ describe('LotsController', () => {
         avg_occupancy_rate: 0.55,
         avg_occupancy: 55,
         avg_available: 45,
+        avg_estimated_occupancy: 78,
+        avg_estimated_rate: 0.78,
         sample_count: 4,
       },
     ];
@@ -306,6 +308,7 @@ describe('LotsController', () => {
         lot_type: 'STUDENT',
         capacity: 100,
         avg_utilization: 0.72,
+        avg_estimated_utilization: 0.85,
         snapshot_count: 10,
       },
     ];

--- a/apps/backend/src/lots/lots.service.spec.ts
+++ b/apps/backend/src/lots/lots.service.spec.ts
@@ -773,6 +773,8 @@ describe('LotsService', () => {
           avg_occupancy_rate: 0.55,
           avg_occupancy: 55,
           avg_available: 45,
+          avg_estimated_occupancy: 78,
+          avg_estimated_rate: 0.78,
           sample_count: BigInt(4),
         },
       ]);
@@ -782,7 +784,28 @@ describe('LotsService', () => {
       expect(result).toHaveLength(1);
       expect(result[0].hour).toBe('2026-04-25T08:00:00.000Z');
       expect(result[0].avg_occupancy_rate).toBe(0.55);
+      expect(result[0].avg_estimated_occupancy).toBe(78);
+      expect(result[0].avg_estimated_rate).toBe(0.78);
       expect(result[0].sample_count).toBe(4);
+    });
+
+    it('passes through null estimated fields for legacy snapshots', async () => {
+      prisma.lot.findFirst.mockResolvedValue(mockLot);
+      prisma.$queryRaw.mockResolvedValue([
+        {
+          hour: new Date('2026-04-25T08:00:00Z'),
+          avg_occupancy_rate: 0.55,
+          avg_occupancy: 55,
+          avg_available: 45,
+          avg_estimated_occupancy: null,
+          avg_estimated_rate: null,
+          sample_count: BigInt(4),
+        },
+      ]);
+
+      const result = await service.getTrends('G1', 7);
+      expect(result[0].avg_estimated_occupancy).toBeNull();
+      expect(result[0].avg_estimated_rate).toBeNull();
     });
 
     it('returns empty array when no snapshots exist', async () => {
@@ -826,8 +849,8 @@ describe('LotsService', () => {
     it('returns per-lot utilization sorted descending', async () => {
       prisma.lot.findMany.mockResolvedValue(lots);
       prisma.occupancySnapshot.groupBy.mockResolvedValue([
-        { lot_id: 'uuid-1', _avg: { occupancy_rate: 0.72 }, _count: { id: 10 } },
-        { lot_id: 'uuid-2', _avg: { occupancy_rate: 0.40 }, _count: { id: 8 } },
+        { lot_id: 'uuid-1', _avg: { occupancy_rate: 0.72, estimated_occupancy: 85 }, _count: { id: 10 } },
+        { lot_id: 'uuid-2', _avg: { occupancy_rate: 0.40, estimated_occupancy: 48 }, _count: { id: 8 } },
       ]);
 
       const result = await service.getUtilization(30);
@@ -835,8 +858,30 @@ describe('LotsService', () => {
       expect(result).toHaveLength(2);
       expect(result[0].lot_id).toBe('G1');
       expect(result[0].avg_utilization).toBe(0.72);
+      // 85 / 100 = 0.85
+      expect(result[0].avg_estimated_utilization).toBe(0.85);
       expect(result[0].snapshot_count).toBe(10);
       expect(result[1].lot_id).toBe('E1');
+      // 48 / 80 = 0.6
+      expect(result[1].avg_estimated_utilization).toBe(0.6);
+    });
+
+    it('sorts by estimated utilization, falling back to raw rate for legacy rows', async () => {
+      prisma.lot.findMany.mockResolvedValue(lots);
+      prisma.occupancySnapshot.groupBy.mockResolvedValue([
+        // G1: only legacy data — no estimate available, raw rate 0.95
+        { lot_id: 'uuid-1', _avg: { occupancy_rate: 0.95, estimated_occupancy: null }, _count: { id: 10 } },
+        // E1: has estimate giving 0.50 fullness
+        { lot_id: 'uuid-2', _avg: { occupancy_rate: 0.30, estimated_occupancy: 40 }, _count: { id: 8 } },
+      ]);
+
+      const result = await service.getUtilization(30);
+
+      // G1 (raw 0.95 fallback) should outrank E1 (estimated 0.50)
+      expect(result[0].lot_id).toBe('G1');
+      expect(result[0].avg_estimated_utilization).toBeNull();
+      expect(result[1].lot_id).toBe('E1');
+      expect(result[1].avg_estimated_utilization).toBe(0.5);
     });
 
     it('sets avg_utilization to null for lots with no snapshots', async () => {
@@ -847,19 +892,21 @@ describe('LotsService', () => {
 
       expect(result).toHaveLength(2);
       expect(result[0].avg_utilization).toBeNull();
+      expect(result[0].avg_estimated_utilization).toBeNull();
       expect(result[0].snapshot_count).toBe(0);
     });
 
     it('sets avg_utilization to null when avg occupancy_rate is null', async () => {
       prisma.lot.findMany.mockResolvedValue(lots);
       prisma.occupancySnapshot.groupBy.mockResolvedValue([
-        { lot_id: 'uuid-1', _avg: { occupancy_rate: null }, _count: { id: 3 } },
+        { lot_id: 'uuid-1', _avg: { occupancy_rate: null, estimated_occupancy: null }, _count: { id: 3 } },
       ]);
 
       const result = await service.getUtilization(30);
 
       const g1 = result.find(r => r.lot_id === 'G1');
       expect(g1?.avg_utilization).toBeNull();
+      expect(g1?.avg_estimated_utilization).toBeNull();
       expect(g1?.snapshot_count).toBe(3);
     });
 

--- a/apps/backend/src/lots/lots.service.ts
+++ b/apps/backend/src/lots/lots.service.ts
@@ -434,14 +434,18 @@ export class LotsService {
         avg_occupancy_rate: number;
         avg_occupancy: number;
         avg_available: number;
+        avg_estimated_occupancy: number | null;
+        avg_estimated_rate: number | null;
         sample_count: bigint;
       }>>`
         SELECT
           date_trunc('hour', timestamp) AS hour,
-          ROUND(AVG(occupancy_rate)::numeric, 3)::float8 AS avg_occupancy_rate,
-          ROUND(AVG(occupancy)::numeric, 1)::float8    AS avg_occupancy,
-          ROUND(AVG(available)::numeric, 1)::float8    AS avg_available,
-          COUNT(*)                                     AS sample_count
+          ROUND(AVG(occupancy_rate)::numeric, 3)::float8           AS avg_occupancy_rate,
+          ROUND(AVG(occupancy)::numeric, 1)::float8                AS avg_occupancy,
+          ROUND(AVG(available)::numeric, 1)::float8                AS avg_available,
+          ROUND(AVG(estimated_occupancy)::numeric, 1)::float8      AS avg_estimated_occupancy,
+          ROUND((AVG(estimated_occupancy) / NULLIF(${lot.capacity}::float8, 0))::numeric, 3)::float8 AS avg_estimated_rate,
+          COUNT(*)                                                 AS sample_count
         FROM occupancy_snapshots
         WHERE lot_id = ${lot.id} AND timestamp >= ${since}
         GROUP BY date_trunc('hour', timestamp)
@@ -453,6 +457,10 @@ export class LotsService {
         avg_occupancy_rate: Number(r.avg_occupancy_rate),
         avg_occupancy: Number(r.avg_occupancy),
         avg_available: Number(r.avg_available),
+        avg_estimated_occupancy:
+          r.avg_estimated_occupancy != null ? Number(r.avg_estimated_occupancy) : null,
+        avg_estimated_rate:
+          r.avg_estimated_rate != null ? Number(r.avg_estimated_rate) : null,
         sample_count: Number(r.sample_count),
       }));
     } catch (error) {
@@ -463,8 +471,15 @@ export class LotsService {
   }
 
   /**
-   * Returns per-lot average utilization (occupancy_rate) over the past N days.
-   * Lots with no snapshots in the range get avg_utilization: null.
+   * Returns per-lot average utilization over the past N days.
+   *
+   * Emits both the raw `avg_utilization` (device-coverage rate) and the
+   * penetration-corrected `avg_estimated_utilization` (true fullness proxy).
+   * Lots with no snapshots in the range get both averages as `null`; lots
+   * that have only legacy snapshots written before the penetration rollout
+   * keep `avg_utilization` populated and `avg_estimated_utilization` null.
+   * Sort order prefers `avg_estimated_utilization` and falls back to the raw
+   * rate so legacy rows still rank.
    */
   async getUtilization(rangeDays: number): Promise<LotUtilization[]> {
     try {
@@ -475,7 +490,7 @@ export class LotsService {
         this.prisma.occupancySnapshot.groupBy({
           by: ['lot_id'],
           where: { timestamp: { gte: since } },
-          _avg: { occupancy_rate: true },
+          _avg: { occupancy_rate: true, estimated_occupancy: true },
           _count: { id: true },
         }),
       ]);
@@ -486,16 +501,27 @@ export class LotsService {
         .map(lot => {
           const agg = aggMap.get(lot.id);
           const rate = agg?._avg.occupancy_rate;
+          const estOcc = agg?._avg.estimated_occupancy;
+          const estRate =
+            estOcc != null && lot.capacity > 0 ? estOcc / lot.capacity : null;
           return {
             lot_id: lot.lot_id,
             display_name: lot.display_name,
             lot_type: lot.lot_type as string,
             capacity: lot.capacity,
             avg_utilization: rate != null ? Math.round(rate * 1000) / 1000 : null,
+            avg_estimated_utilization:
+              estRate != null ? Math.round(estRate * 1000) / 1000 : null,
             snapshot_count: agg?._count.id ?? 0,
           };
         })
-        .sort((a, b) => (b.avg_utilization ?? -1) - (a.avg_utilization ?? -1));
+        // Sort by penetration-corrected utilization when available; fall back
+        // to the raw rate so older lots without estimates still rank.
+        .sort(
+          (a, b) =>
+            (b.avg_estimated_utilization ?? b.avg_utilization ?? -1) -
+            (a.avg_estimated_utilization ?? a.avg_utilization ?? -1),
+        );
     } catch (error) {
       this.logger.error('Failed to fetch lot utilization', error);
       throw new InternalServerErrorException('Failed to fetch lot utilization');

--- a/apps/backend/test/lots.e2e-spec.ts
+++ b/apps/backend/test/lots.e2e-spec.ts
@@ -243,6 +243,7 @@ describe('LotsController (e2e)', () => {
             expect(item).toHaveProperty('lot_type');
             expect(typeof item.capacity).toBe('number');
             expect(item).toHaveProperty('avg_utilization');
+            expect(item).toHaveProperty('avg_estimated_utilization');
             expect(typeof item.snapshot_count).toBe('number');
           }
         });
@@ -283,6 +284,8 @@ describe('LotsController (e2e)', () => {
             expect(typeof point.avg_occupancy_rate).toBe('number');
             expect(typeof point.avg_occupancy).toBe('number');
             expect(typeof point.avg_available).toBe('number');
+            expect(point).toHaveProperty('avg_estimated_occupancy');
+            expect(point).toHaveProperty('avg_estimated_rate');
             expect(typeof point.sample_count).toBe('number');
           }
         });


### PR DESCRIPTION
Follow-up to #163 addressing Zach's review note:

> The trends endpoint uses raw `occupancy_snapshots` data — if this endpoint were to be used for measuring actual lot occupancies, it would likely be better to average `estimated_occupancy / capacity`.

He's right. Raw `occupancy_rate` is a device-coverage signal — it understates fullness whenever penetration < 100%. The good news: `OccupancySnapshot.estimated_occupancy` is already populated at write time by the snapshot job (apps/backend/src/occupancy-events/occupancy-events.service.ts), scaled by the live penetration rate from `PenetrationEstimationService`. No backfill or schema change needed — we just expose it.

## Changes

**`GET /lots/:id/trends`** — each hourly bucket now also returns:
- `avg_estimated_occupancy` — average scaled vehicle count
- `avg_estimated_rate` — `AVG(estimated_occupancy) / capacity`, the actual fullness proxy

Both are `null` for buckets whose snapshots were all written before the penetration rollout.

**`GET /lots/utilization`** — each lot now also returns `avg_estimated_utilization`. Sort order prefers it, falling back to `avg_utilization` so legacy-only lots still rank.

**Backward compatibility** — existing `avg_occupancy_rate` / `avg_utilization` fields are unchanged. Doc comments on the interfaces explain which to prefer.

## Tests
- `lots.service.spec.ts` — added new-fields case + legacy fallback case + sort-fallback case
- `lots.controller.spec.ts` — mock fixtures updated
- `lots.e2e-spec.ts` — shape assertions cover new fields
- 72/72 unit tests pass; lint + build clean

cc @zachhalbert