### PR TITLE
fix(mobile): close report modal and stay on lot after submission

### DIFF
--- a/apps/mobile/ios/Podfile
+++ b/apps/mobile/ios/Podfile
@@ -8,6 +8,12 @@ require Pod::Executable.execute_command('node', ['-p',
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
+# Pin Firebase SDK version to match react-native-firebase@24.0.0 expectations.
+# Without this, CocoaPods 1.16.x SPM resolver independently picks up a newer
+# Firebase version (e.g. 12.13.0) while CocoaPods itself stays on 12.10.0,
+# causing 'invalid custom path FirebaseSharedSwift/Sources' at build time.
+$FirebaseSDKVersion = '12.10.0'
+
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil
   Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
@@ -51,6 +57,40 @@ target 'mobile' do
         target.build_configurations.each do |config|
           config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
         end
+      end
+    end
+
+    # Xcode 26 introduced "Explicitly Built Modules" which generates its own
+    # module maps for every pod regardless of DEFINES_MODULE, causing
+    # "redefinition of module 'FirebaseCore'" for pods that already ship module
+    # maps via :modular_headers => true. Disabling it on the Pods project,
+    # all pod targets, AND the main app project fixes the cascade.
+    [installer.pods_project, installer.aggregate_targets.first&.user_project].compact.each do |proj|
+      proj.build_configurations.each do |cfg|
+        cfg.build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'
+      end
+      proj.targets.each do |target|
+        target.build_configurations.each do |cfg|
+          cfg.build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'
+        end
+      end
+      proj.save
+    end
+
+    # Belt-and-suspenders: also keep DEFINES_MODULE off for Firebase pods that
+    # already supply their own module maps via :modular_headers above.
+    firebase_pods_with_own_modulemaps = %w[
+      FirebaseCore
+      FirebaseCoreInternal
+      FirebaseCoreExtension
+      FirebaseInstallations
+      FirebaseMessaging
+      GoogleUtilities
+    ]
+    installer.pods_project.targets.each do |target|
+      next unless firebase_pods_with_own_modulemaps.include?(target.name)
+      target.build_configurations.each do |cfg|
+        cfg.build_settings['DEFINES_MODULE'] = 'NO'
       end
     end
     # ----------------------------

--- a/apps/mobile/ios/Podfile
+++ b/apps/mobile/ios/Podfile
@@ -65,7 +65,8 @@ target 'mobile' do
     # "redefinition of module 'FirebaseCore'" for pods that already ship module
     # maps via :modular_headers => true. Disabling it on the Pods project,
     # all pod targets, AND the main app project fixes the cascade.
-    [installer.pods_project, installer.aggregate_targets.first&.user_project].compact.each do |proj|
+    user_projects = installer.aggregate_targets.map(&:user_project).compact.uniq
+    [installer.pods_project, *user_projects].each do |proj|
       proj.build_configurations.each do |cfg|
         cfg.build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'
       end

--- a/apps/mobile/ios/Podfile
+++ b/apps/mobile/ios/Podfile
@@ -8,10 +8,16 @@ require Pod::Executable.execute_command('node', ['-p',
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
-# Pin Firebase SDK version to match react-native-firebase@24.0.0 expectations.
-# Without this, CocoaPods 1.16.x SPM resolver independently picks up a newer
+# Pin Firebase SDK version to match @react-native-firebase/app@24.x expectations.
+# Without this, CocoaPods 1.16.x's SPM resolver independently picks up a newer
 # Firebase version (e.g. 12.13.0) while CocoaPods itself stays on 12.10.0,
 # causing 'invalid custom path FirebaseSharedSwift/Sources' at build time.
+#
+# BUMP CONTRACT: when upgrading @react-native-firebase/* major versions, update
+# this pin to match the Firebase iOS SDK version listed in that release's
+# `ios/firebase_sdk_version.rb` (or the package's RNFBVersions table). Leaving
+# this stale on a major bump will silently downgrade Firebase below what the
+# JS layer expects and break runtime initialization.
 $FirebaseSDKVersion = '12.10.0'
 
 linkage = ENV['USE_FRAMEWORKS']

--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -6,9 +6,85 @@ PODS:
   - AppAuth/ExternalUserAgent (2.0.0):
     - AppAuth/Core
   - FBLazyVector (0.85.2)
+  - Firebase/CoreOnly (12.10.0):
+    - FirebaseCore (~> 12.10.0)
+  - Firebase/Messaging (12.10.0):
+    - Firebase/CoreOnly
+    - FirebaseMessaging (~> 12.10.0)
+  - FirebaseCore (12.10.0):
+    - FirebaseCoreInternal (~> 12.10.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Logger (~> 8.1)
+  - FirebaseCoreExtension (12.10.0):
+    - FirebaseCore (~> 12.10.0)
+  - FirebaseCoreInternal (12.10.0):
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+  - FirebaseInstallations (12.10.0):
+    - FirebaseCore (~> 12.10.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - PromisesObjC (~> 2.4)
+  - FirebaseMessaging (12.10.0):
+    - FirebaseCore (~> 12.10.0)
+    - FirebaseInstallations (~> 12.10.0)
+    - GoogleDataTransport (~> 10.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Reachability (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - nanopb (~> 3.30910.0)
+  - GoogleDataTransport (10.1.0):
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - GoogleUtilities (8.1.0):
+    - GoogleUtilities/AppDelegateSwizzler (= 8.1.0)
+    - GoogleUtilities/Environment (= 8.1.0)
+    - GoogleUtilities/Logger (= 8.1.0)
+    - GoogleUtilities/MethodSwizzler (= 8.1.0)
+    - GoogleUtilities/Network (= 8.1.0)
+    - "GoogleUtilities/NSData+zlib (= 8.1.0)"
+    - GoogleUtilities/Privacy (= 8.1.0)
+    - GoogleUtilities/Reachability (= 8.1.0)
+    - GoogleUtilities/SwizzlerTestHelpers (= 8.1.0)
+    - GoogleUtilities/UserDefaults (= 8.1.0)
+  - GoogleUtilities/AppDelegateSwizzler (8.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Environment (8.1.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Logger (8.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/MethodSwizzler (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (8.1.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (8.1.0)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (8.1.0)
+  - GoogleUtilities/Reachability (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/SwizzlerTestHelpers (8.1.0):
+    - GoogleUtilities/MethodSwizzler
+  - GoogleUtilities/UserDefaults (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
   - hermes-engine (250829098.0.10):
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
+  - nanopb (3.30910.0):
+    - nanopb/decode (= 3.30910.0)
+    - nanopb/encode (= 3.30910.0)
+  - nanopb/decode (3.30910.0)
+  - nanopb/encode (3.30910.0)
+  - PromisesObjC (2.4.0)
   - RCTDeprecation (0.85.2)
   - RCTRequired (0.85.2)
   - RCTSwiftUI (0.85.2)
@@ -1963,6 +2039,54 @@ PODS:
     - Yoga
   - RNDeviceInfo (15.0.2):
     - React-Core
+  - RNFBApp (24.0.0):
+    - Firebase/CoreOnly (= 12.10.0)
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - RNFBMessaging (24.0.0):
+    - Firebase/Messaging (= 12.10.0)
+    - FirebaseCoreExtension
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - RNFBApp
+    - Yoga
   - RNGestureHandler (2.31.1):
     - hermes-engine
     - RCTRequired
@@ -2301,6 +2425,10 @@ PODS:
 DEPENDENCIES:
   - AppAuth
   - FBLazyVector (from `../../../node_modules/react-native/Libraries/FBLazyVector`)
+  - FirebaseCore
+  - FirebaseCoreInternal
+  - FirebaseInstallations
+  - GoogleUtilities
   - hermes-engine (from `../../../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - RCTDeprecation (from `../../../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
   - RCTRequired (from `../../../node_modules/react-native/Libraries/Required`)
@@ -2381,6 +2509,8 @@ DEPENDENCIES:
   - RNBackgroundGeolocation (from `../../../node_modules/react-native-background-geolocation`)
   - "RNCAsyncStorage (from `../../../node_modules/@react-native-async-storage/async-storage`)"
   - RNDeviceInfo (from `../../../node_modules/react-native-device-info`)
+  - "RNFBApp (from `../../../node_modules/@react-native-firebase/app`)"
+  - "RNFBMessaging (from `../../../node_modules/@react-native-firebase/messaging`)"
   - RNGestureHandler (from `../../../node_modules/react-native-gesture-handler`)
   - RNKeychain (from `../../../node_modules/react-native-keychain`)
   - RNReanimated (from `../../../node_modules/react-native-reanimated`)
@@ -2394,6 +2524,16 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - AppAuth
+    - Firebase
+    - FirebaseCore
+    - FirebaseCoreExtension
+    - FirebaseCoreInternal
+    - FirebaseInstallations
+    - FirebaseMessaging
+    - GoogleDataTransport
+    - GoogleUtilities
+    - nanopb
+    - PromisesObjC
     - Sentry
     - TSBackgroundFetch
     - TSLocationManager
@@ -2560,6 +2700,10 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/@react-native-async-storage/async-storage"
   RNDeviceInfo:
     :path: "../../../node_modules/react-native-device-info"
+  RNFBApp:
+    :path: "../../../node_modules/@react-native-firebase/app"
+  RNFBMessaging:
+    :path: "../../../node_modules/@react-native-firebase/messaging"
   RNGestureHandler:
     :path: "../../../node_modules/react-native-gesture-handler"
   RNKeychain:
@@ -2582,7 +2726,17 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   FBLazyVector: 26fd21c75314e101f280d401e97f27d54f3f7064
+  Firebase: 99f203d3a114c6ba591f3b32263a9626e450af65
+  FirebaseCore: f4428e22415ea3b3eca652c2098413dabf2a23a9
+  FirebaseCoreExtension: 3473a6ec16a91aee29fb75994a86c0220d2cddf3
+  FirebaseCoreInternal: e7bbaeb00ab73011298f35ed223aa7371e212948
+  FirebaseInstallations: 047343aa91fd6a1ebfa3eb374ddecf36a8aaddfd
+  FirebaseMessaging: ed18fb50634e6e85b5d3e77e628c21e2c928cc53
+  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
+  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: c21a31ab00a5f488dd100494f9f511461b69b504
+  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCTDeprecation: c7a2768f905d76ca6d2cfefb26e4349eacbdfca3
   RCTRequired: 5e502c3553cfbed090a991c444448da452fb752e
   RCTSwiftUI: 5ce3ccbdc58b78cc4ebbaace01709ec22d58e131
@@ -2661,6 +2815,8 @@ SPEC CHECKSUMS:
   RNBackgroundGeolocation: ce3b7173820e25a7eb93a0636e43679aa02ef0c1
   RNCAsyncStorage: 0f84413588571e74ef9cff6e3b669346e3abf9cb
   RNDeviceInfo: d79872e11c8e9c4de0d65b0ee6e0cee719f37fea
+  RNFBApp: 87b0a7d66a333c9b6d0de5ec99c51a649a1a3e1e
+  RNFBMessaging: af337b6d79482aa646ab264992518a6e0b378ebb
   RNGestureHandler: 8f110d136971c0d720c3fe78dc352ccfce1cde9c
   RNKeychain: 1b055a0ec36d058cb0a075e965d8c9d335e0c828
   RNReanimated: f26f3044ea86e3878fb2db213297d0810dd8f779
@@ -2672,8 +2828,8 @@ SPEC CHECKSUMS:
   Sentry: 19f0f2f9d0d51f2234e270962e7c060bef1bd05c
   TSBackgroundFetch: 18918b6449a1e3f01eb0f5b44d6d79ce6160a5a5
   TSLocationManager: 7dd12e7e98191abc74327a017560c4eced17a83d
-  Yoga: df8920a8f8ca99996048f6aea23a529f44992eac
+  Yoga: 04bb4bfeb02c0000b940c1e6e89e856cd8de5a71
 
-PODFILE CHECKSUM: a2317119dc8d638e189dd99b0f8428616223d612
+PODFILE CHECKSUM: 0c07d37198f15dca245b5cc93c92a33e484e80f4
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/apps/mobile/ios/mobile.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/mobile.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		4EC621C5AA78415D9F4F563F /* Inter-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 870DFBDF32FA42C181C05B52 /* Inter-Regular.ttf */; };
 		6B58D14F33664403999355FB /* Inter-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5748CDB7AA6947018E4DBE10 /* Inter-SemiBold.ttf */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
-		81A422202FA47A2D004C53DF /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 81A4221F2FA47A2D004C53DF /* FirebaseMessaging */; };
 		81A422252FA70C78004C53DF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 81A422242FA70C78004C53DF /* GoogleService-Info.plist */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		BE967F942B1C4A3A87CCDA24 /* CarBluetoothModuleBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 084D61FD6E89423095EF2227 /* CarBluetoothModuleBridge.m */; };
@@ -47,7 +46,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				81A422202FA47A2D004C53DF /* FirebaseMessaging in Frameworks */,
 				0C80B921A6F3F58F76C31292 /* libPods-mobile.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -143,6 +141,7 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */,
 				E235C05ADACE081382539298 /* [CP] Copy Pods Resources */,
+				9D538CD55007032C51BEA1F2 /* [CP-User] [RNFB] Core Configuration */,
 			);
 			buildRules = (
 			);
@@ -175,9 +174,6 @@
 				Base,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
-			packageReferences = (
-				81A4221E2FA47A2D004C53DF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
-			);
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -238,6 +234,19 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-mobile/Pods-mobile-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		9D538CD55007032C51BEA1F2 /* [CP-User] [RNFB] Core Configuration */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "[CP-User] [RNFB] Core Configuration";
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/usr/bin/env bash\n#\n# Copyright (c) 2016-present Invertase Limited & Contributors\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this library except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\n\n##########################################################################\n##########################################################################\n#\n#  NOTE THAT IF YOU CHANGE THIS FILE YOU MUST RUN pod install AFTERWARDS\n#\n#  This file is installed as an Xcode build script in the project file\n#  by cocoapods, and you will not see your changes until you pod install\n#\n##########################################################################\n##########################################################################\n\nset -e\n\n_MAX_LOOKUPS=2;\n_SEARCH_RESULT=''\n_RN_ROOT_EXISTS=''\n_CURRENT_LOOKUPS=1\n_JSON_ROOT=\"'react-native'\"\n_JSON_FILE_NAME='firebase.json'\n_JSON_OUTPUT_BASE64='e30=' # { }\n_CURRENT_SEARCH_DIR=${PROJECT_DIR}\n_PLIST_BUDDY=/usr/libexec/PlistBuddy\n_TARGET_PLIST=\"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"\n_DSYM_PLIST=\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist\"\n\n# plist arrays\n_PLIST_ENTRY_KEYS=()\n_PLIST_ENTRY_TYPES=()\n_PLIST_ENTRY_VALUES=()\n\nfunction setPlistValue {\n  echo \"note:      setting plist entry '$1' of type '$2' in file '$4'\"\n  ${_PLIST_BUDDY} -c \"Add :$1 $2 '$3'\" $4 || echo \"note:      '$1' already exists\"\n}\n\nfunction getFirebaseJsonKeyValue () {\n  if [[ ${_RN_ROOT_EXISTS} ]]; then\n    ruby -Ku -e \"require 'rubygems';require 'json'; output=JSON.parse('$1'); puts output[$_JSON_ROOT]['$2']\"\n  else\n    echo \"\"\n  fi;\n}\n\nfunction jsonBoolToYesNo () {\n  if [[ $1 == \"false\" ]]; then\n    echo \"NO\"\n  elif [[ $1 == \"true\" ]]; then\n    echo \"YES\"\n  else echo \"NO\"\n  fi\n}\n\necho \"note: -> RNFB build script started\"\necho \"note: 1) Locating ${_JSON_FILE_NAME} file:\"\n\nif [[ -z ${_CURRENT_SEARCH_DIR} ]]; then\n  _CURRENT_SEARCH_DIR=$(pwd)\nfi;\n\nwhile true; do\n  _CURRENT_SEARCH_DIR=$(dirname \"$_CURRENT_SEARCH_DIR\")\n  if [[ \"$_CURRENT_SEARCH_DIR\" == \"/\" ]] || [[ ${_CURRENT_LOOKUPS} -gt ${_MAX_LOOKUPS} ]]; then break; fi;\n  echo \"note:      ($_CURRENT_LOOKUPS of $_MAX_LOOKUPS) Searching in '$_CURRENT_SEARCH_DIR' for a ${_JSON_FILE_NAME} file.\"\n  _SEARCH_RESULT=$(find \"$_CURRENT_SEARCH_DIR\" -maxdepth 2 -name ${_JSON_FILE_NAME} -print | /usr/bin/head -n 1)\n  if [[ ${_SEARCH_RESULT} ]]; then\n    echo \"note:      ${_JSON_FILE_NAME} found at $_SEARCH_RESULT\"\n    break;\n  fi;\n  _CURRENT_LOOKUPS=$((_CURRENT_LOOKUPS+1))\ndone\n\nif [[ ${_SEARCH_RESULT} ]]; then\n  _JSON_OUTPUT_RAW=$(cat \"${_SEARCH_RESULT}\")\n  if ! _RN_ROOT_EXISTS=$(ruby -Ku -e \"require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); puts output[$_JSON_ROOT]\"); then\n    echo \"error: Failed to parse firebase.json, check for syntax errors.\"\n    exit 1\n  fi\n\n  if [[ ${_RN_ROOT_EXISTS} ]]; then\n    if ! python3 --version >/dev/null 2>&1; then echo \"error: python3 not found, firebase.json file processing error.\" && exit 1; fi\n    _JSON_OUTPUT_BASE64=$(python3 -c 'import json,sys,base64;print(base64.b64encode(bytes(json.dumps(json.loads(open('\"'${_SEARCH_RESULT}'\"', '\"'rb'\"').read())['${_JSON_ROOT}']), '\"'utf-8'\"')).decode())' || echo \"e30=\")\n  fi\n\n  _PLIST_ENTRY_KEYS+=(\"firebase_json_raw\")\n  _PLIST_ENTRY_TYPES+=(\"string\")\n  _PLIST_ENTRY_VALUES+=(\"$_JSON_OUTPUT_BASE64\")\n\n  # config.app_data_collection_default_enabled\n  _APP_DATA_COLLECTION_ENABLED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"app_data_collection_default_enabled\")\n  if [[ $_APP_DATA_COLLECTION_ENABLED ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseDataCollectionDefaultEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_APP_DATA_COLLECTION_ENABLED\")\")\n  fi\n\n  # config.analytics_auto_collection_enabled\n  _ANALYTICS_AUTO_COLLECTION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_auto_collection_enabled\")\n  if [[ $_ANALYTICS_AUTO_COLLECTION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FIREBASE_ANALYTICS_COLLECTION_ENABLED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AUTO_COLLECTION\")\")\n  fi\n\n  # config.analytics_collection_deactivated\n  _ANALYTICS_DEACTIVATED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_collection_deactivated\")\n  if [[ $_ANALYTICS_DEACTIVATED ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_DEACTIVATED\")\")\n  fi\n\n  # config.analytics_idfv_collection_enabled\n  _ANALYTICS_IDFV_COLLECTION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_idfv_collection_enabled\")\n  if [[ $_ANALYTICS_IDFV_COLLECTION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_IDFV_COLLECTION_ENABLED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_IDFV_COLLECTION\")\")\n  fi\n\n  # config.analytics_default_allow_analytics_storage\n  _ANALYTICS_STORAGE=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_analytics_storage\")\n  if [[ $_ANALYTICS_STORAGE ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_ANALYTICS_STORAGE\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_STORAGE\")\")\n  fi\n\n  # config.analytics_default_allow_ad_storage\n  _ANALYTICS_AD_STORAGE=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_ad_storage\")\n  if [[ $_ANALYTICS_AD_STORAGE ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_STORAGE\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AD_STORAGE\")\")\n  fi\n\n  # config.analytics_default_allow_ad_user_data\n  _ANALYTICS_AD_USER_DATA=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_ad_user_data\")\n  if [[ $_ANALYTICS_AD_USER_DATA ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_USER_DATA\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AD_USER_DATA\")\")\n  fi\n\n  # config.analytics_default_allow_ad_personalization_signals\n  _ANALYTICS_PERSONALIZATION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_ad_personalization_signals\")\n  if [[ $_ANALYTICS_PERSONALIZATION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_PERSONALIZATION_SIGNALS\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_PERSONALIZATION\")\")\n  fi\n\n  # config.analytics_registration_with_ad_network_enabled\n  _ANALYTICS_REGISTRATION_WITH_AD_NETWORK=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"google_analytics_registration_with_ad_network_enabled\")\n  if [[ $_ANALYTICS_REGISTRATION_WITH_AD_NETWORK ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_REGISTRATION_WITH_AD_NETWORK_ENABLED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_REGISTRATION_WITH_AD_NETWORK\")\")\n  fi\n\n  # config.google_analytics_automatic_screen_reporting_enabled\n  _ANALYTICS_AUTO_SCREEN_REPORTING=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"google_analytics_automatic_screen_reporting_enabled\")\n  if [[ $_ANALYTICS_AUTO_SCREEN_REPORTING ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseAutomaticScreenReportingEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AUTO_SCREEN_REPORTING\")\")\n  fi\n\n  # config.perf_auto_collection_enabled\n  _PERF_AUTO_COLLECTION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"perf_auto_collection_enabled\")\n  if [[ $_PERF_AUTO_COLLECTION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"firebase_performance_collection_enabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_PERF_AUTO_COLLECTION\")\")\n  fi\n\n  # config.perf_collection_deactivated\n  _PERF_DEACTIVATED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"perf_collection_deactivated\")\n  if [[ $_PERF_DEACTIVATED ]]; then\n    _PLIST_ENTRY_KEYS+=(\"firebase_performance_collection_deactivated\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_PERF_DEACTIVATED\")\")\n  fi\n\n  # config.messaging_auto_init_enabled\n  _MESSAGING_AUTO_INIT=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"messaging_auto_init_enabled\")\n  if [[ $_MESSAGING_AUTO_INIT ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseMessagingAutoInitEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_MESSAGING_AUTO_INIT\")\")\n  fi\n\n  # config.in_app_messaging_auto_colllection_enabled\n  _FIAM_AUTO_INIT=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"in_app_messaging_auto_collection_enabled\")\n  if [[ $_FIAM_AUTO_INIT ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseInAppMessagingAutomaticDataCollectionEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_FIAM_AUTO_INIT\")\")\n  fi\n\n  # config.app_check_token_auto_refresh\n  _APP_CHECK_TOKEN_AUTO_REFRESH=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"app_check_token_auto_refresh\")\n  if [[ $_APP_CHECK_TOKEN_AUTO_REFRESH ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseAppCheckTokenAutoRefreshEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_APP_CHECK_TOKEN_AUTO_REFRESH\")\")\n  fi\n\n  # config.crashlytics_disable_auto_disabler - undocumented for now - mainly for debugging, document if becomes useful\n  _CRASHLYTICS_AUTO_DISABLE_ENABLED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"crashlytics_disable_auto_disabler\")\n  if [[ $_CRASHLYTICS_AUTO_DISABLE_ENABLED == \"true\" ]]; then\n    echo \"Disabled Crashlytics auto disabler.\" # do nothing\n  else\n    _PLIST_ENTRY_KEYS+=(\"FirebaseCrashlyticsCollectionEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"NO\")\n  fi\nelse\n  _PLIST_ENTRY_KEYS+=(\"firebase_json_raw\")\n  _PLIST_ENTRY_TYPES+=(\"string\")\n  _PLIST_ENTRY_VALUES+=(\"$_JSON_OUTPUT_BASE64\")\n  echo \"warning:   A firebase.json file was not found, whilst this file is optional it is recommended to include it to configure firebase services in React Native Firebase.\"\nfi;\n\necho \"note: 2) Injecting Info.plist entries: \"\n\n# Log out the keys we're adding\nfor i in \"${!_PLIST_ENTRY_KEYS[@]}\"; do\n  echo \"    ->  $i) ${_PLIST_ENTRY_KEYS[$i]}\" \"${_PLIST_ENTRY_TYPES[$i]}\" \"${_PLIST_ENTRY_VALUES[$i]}\"\ndone\n\nfor plist in \"${_TARGET_PLIST}\" \"${_DSYM_PLIST}\" ; do\n  if [[ -f \"${plist}\" ]]; then\n\n    # paths with spaces break the call to setPlistValue. temporarily modify\n    # the shell internal field separator variable (IFS), which normally\n    # includes spaces, to consist only of line breaks\n    oldifs=$IFS\n    IFS=\"\n\"\n\n    for i in \"${!_PLIST_ENTRY_KEYS[@]}\"; do\n      setPlistValue \"${_PLIST_ENTRY_KEYS[$i]}\" \"${_PLIST_ENTRY_TYPES[$i]}\" \"${_PLIST_ENTRY_VALUES[$i]}\" \"${plist}\"\n    done\n\n    # restore the original internal field separator value\n    IFS=$oldifs\n  else\n    echo \"warning:   A Info.plist build output file was not found (${plist})\"\n  fi\ndone\n\necho \"note: <- RNFB build script finished\"\n";
 		};
 		C38B50BA6285516D6DCD4F65 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -300,6 +309,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BG_GEOLOCATION_LICENSE = "";
+				CLANG_ENABLE_EXPLICIT_MODULES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -334,6 +344,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BG_GEOLOCATION_LICENSE = "";
+				CLANG_ENABLE_EXPLICIT_MODULES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = mobile/mobile.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
@@ -365,6 +376,7 @@
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_EXPLICIT_MODULES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
@@ -447,6 +459,7 @@
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_EXPLICIT_MODULES = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
@@ -536,25 +549,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		81A4221E2FA47A2D004C53DF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 12.12.1;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		81A4221F2FA47A2D004C53DF /* FirebaseMessaging */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 81A4221E2FA47A2D004C53DF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseMessaging;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
 }

--- a/apps/mobile/src/screens/ShortTermForecastScreen.tsx
+++ b/apps/mobile/src/screens/ShortTermForecastScreen.tsx
@@ -10,7 +10,6 @@ import {
 import { Text } from '../components/CustomText';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import Icon from 'react-native-vector-icons/Ionicons';
-import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import { COLORS, TYPOGRAPHY, SPACING, SHADOWS } from '../constants/theme';
 import { Header, ReliabilityRow, LockedOccupancyBadge, LockedForecastCard, UnlockCTAButton } from '../components';
 import { useTheme } from '../context/ThemeContext';
@@ -401,7 +400,7 @@ export function ShortTermForecastScreen() {
         accessibilityLabel="Report an incident"
         importantForAccessibility="yes"
       >
-        <MaterialIcon
+        <Icon
           name="warning"
           size={TYPOGRAPHY.fontSize.xxxxl}
           color={COLORS.white}

--- a/apps/mobile/src/screens/ShortTermForecastScreen.tsx
+++ b/apps/mobile/src/screens/ShortTermForecastScreen.tsx
@@ -110,7 +110,7 @@ export function ShortTermForecastScreen() {
   const handleReportSubmit = async (report: import('../components/Modals/ReportModal').IncidentReport) => {
     if (isGuest || !isAuthenticated) {
       setIsReportModalOpen(false);
-      navigation.navigate('Profile' as never);
+      Alert.alert('Sign in required', 'Please sign in to submit a report.');
       return;
     }
     if (!lot?.id) throw new Error('Lot data unavailable. Please try again.');
@@ -120,10 +120,11 @@ export function ShortTermForecastScreen() {
         type: report.type,
         message: report.message || undefined,
       });
+      setIsReportModalOpen(false);
     } catch (err) {
       if (err instanceof ReportUnauthorizedError) {
         setIsReportModalOpen(false);
-        navigation.navigate('Profile' as never);
+        Alert.alert('Sign in required', 'Please sign in to submit a report.');
         return;
       }
       if (err instanceof ReportThrottledError) {


### PR DESCRIPTION
# fix(mobile): close report modal and stay on lot after submission

## Summary

This PR fixes two issues:

1. **Report modal navigation bug** — submitting a report (or attempting to while unauthenticated) was redirecting the user to the Profile tab instead of keeping them on the lot screen.
2. **iOS build failure** — Xcode 26 introduced a module system change that, combined with a duplicate Firebase integration (CocoaPods + SPM), caused the build to fail with `redefinition of module 'FirebaseCore'`.

---

## 1. Report Modal Navigation Bug

### What was wrong

In `ShortTermForecastScreen.tsx`, `handleReportSubmit` had two calls to `navigation.navigate('Profile' as never)`:

```tsx
// Case 1: user is a guest or not authenticated
if (isGuest || !isAuthenticated) {
  setIsReportModalOpen(false);
  navigation.navigate('Profile' as never); //  wrong — sends user to Profile tab
  return;
}

// Case 2: server returns 401/403
} catch (err) {
  if (err instanceof ReportUnauthorizedError) {
    setIsReportModalOpen(false);
    navigation.navigate('Profile' as never); //  wrong — same problem
    return;
  }
}
```

Both cases were supposed to prompt the user to sign in, but instead silently dropped them into the Profile tab with no explanation. Additionally, a **successful** submission never called `setIsReportModalOpen(false)`, so the modal remained open after the report was sent.

### What we changed

- **Guest / unauthenticated:** Close the modal and show `Alert.alert('Sign in required', 'Please sign in to submit a report.')` instead of navigating away.
- **`ReportUnauthorizedError`:** Same — close modal, show alert.
- **Successful submission:** Added `setIsReportModalOpen(false)` so the modal actually closes.

```tsx
// After
if (isGuest || !isAuthenticated) {
  setIsReportModalOpen(false);
  Alert.alert('Sign in required', 'Please sign in to submit a report.'); // 
  return;
}
// ...
await reportsApi.create({ ... });
setIsReportModalOpen(false); //  close on success
// ...
if (err instanceof ReportUnauthorizedError) {
  setIsReportModalOpen(false);
  Alert.alert('Sign in required', 'Please sign in to submit a report.'); // 
  return;
}
```

**Files changed:** `apps/mobile/src/screens/ShortTermForecastScreen.tsx`

---

## 2. iOS Build Failure — Root Cause Analysis & Fix

This took significant investigation because the failure had three distinct, compounding layers. Here is the full chain.

### Environment

| Component | Version |
|---|---|
| Xcode | 26.0 (Build 17A324) |
| iOS Simulator SDK | 26.0 |
| CocoaPods (before fix) | 1.15.2 |
| CocoaPods (after fix) | 1.16.2 |
| Ruby | 3.3.11 (via rbenv) |
| `@react-native-firebase/app` | 24.0.0 |
| Firebase iOS SDK (CocoaPods) | 12.10.0 |

---

### Layer 1 — Xcode 26 Explicitly Built Modules

**Error:**
```
Pods/Headers/Public/FirebaseCore/FirebaseCore.modulemap:1:8:
  error: redefinition of module 'FirebaseCore'
```

**Root cause:**

Xcode 26 introduced **Explicitly Built Modules** (`CLANG_ENABLE_EXPLICIT_MODULES`), a new compilation model where Xcode auto-generates its own module map for every target it builds — regardless of whether the target already ships a module map of its own.

Our `Podfile` had the following lines, which are required for `@react-native-firebase` to compile because Firebase's Swift pods depend on GoogleUtilities:

```ruby
pod 'GoogleUtilities',        :modular_headers => true
pod 'FirebaseCore',           :modular_headers => true
pod 'FirebaseCoreInternal',   :modular_headers => true
pod 'FirebaseInstallations',  :modular_headers => true
```

`:modular_headers => true` tells CocoaPods to generate and expose a module map for these pods. Xcode 26 then *also* generated its own module map for the same pods. The compiler saw two module definitions for `FirebaseCore` (one from CocoaPods, one from Xcode 26's auto-generation) and failed.

**Fix:**

Disable `CLANG_ENABLE_EXPLICIT_MODULES` on both the Pods project and the main app project via `post_install`:

```ruby
[installer.pods_project, installer.aggregate_targets.first&.user_project].compact.each do |proj|
  proj.build_configurations.each do |cfg|
    cfg.build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'
  end
  proj.targets.each do |target|
    target.build_configurations.each do |cfg|
      cfg.build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'
    end
  end
  proj.save
end
```

We also added `DEFINES_MODULE = NO` as a belt-and-suspenders measure for the specific Firebase pods that already supply their own module maps, to prevent CocoaPods itself from re-emitting them:

```ruby
firebase_pods_with_own_modulemaps = %w[
  FirebaseCore FirebaseCoreInternal FirebaseCoreExtension
  FirebaseInstallations FirebaseMessaging GoogleUtilities
]
installer.pods_project.targets.each do |target|
  next unless firebase_pods_with_own_modulemaps.include?(target.name)
  target.build_configurations.each do |cfg|
    cfg.build_settings['DEFINES_MODULE'] = 'NO'
  end
end
```

---

### Layer 2 — CocoaPods 1.15.2 Double-Emitting `-fmodule-map-file=` Flags

**Root cause:**

CocoaPods 1.15.2 had a known bug where it emitted duplicate `-fmodule-map-file=` compiler flags for certain pods in the generated xcconfig files. Under Xcode 26's stricter module validation, duplicate flags triggered the same `redefinition` error through a second code path.

**Fix:** Upgraded CocoaPods from **1.15.2 → 1.16.2** using Ruby 3.3.11 via rbenv. CocoaPods 1.16.x deduplicated the flag emission, eliminating this second trigger.

---

### Layer 3 (Root Cause) — Duplicate Firebase Integration: CocoaPods + Direct SPM Reference

**Error (after Layer 2 fix):**
```
invalid custom path 'FirebaseSharedSwift/Sources' for target 'FirebaseSharedSwift'
```

**Root cause:**

At some point in the project's history, a direct **Swift Package Manager (SPM) reference** to `firebase-ios-sdk` was added to `mobile.xcodeproj/project.pbxproj`:

```
81A4221E2FA47A2D004C53DF /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
    isa = XCRemoteSwiftPackageReference;
    repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
    requirement = {
        kind = upToNextMajorVersion;
        minimumVersion = 12.12.1;   ← this is the problem
    };
};
```

This means Firebase was being pulled in **twice**:

| Integration | Version resolved |
|---|---|
| CocoaPods (via `react-native-firebase@24.0.0`) | **12.10.0** (pinned by RNFirebase) |
| Direct SPM reference in `project.pbxproj` | **12.13.0** (resolved from `upToNextMajorVersion 12.12.1`) |

Xcode independently resolved the SPM reference to the latest compatible version (12.13.0) while CocoaPods stayed on 12.10.0. The version mismatch caused the `FirebaseSharedSwift/Sources` path error because 12.13.0 restructured that module's source layout.

**Investigation path:**

Pinning `$FirebaseSDKVersion = '12.10.0'` in the `Podfile` only controls CocoaPods — it does not affect Xcode's independent SPM resolution. Changing the SPM requirement to `exactVersion = 12.10.0` also didn't fully resolve it because Firebase was still being loaded twice regardless of version alignment: CocoaPods provided the module maps via `:modular_headers`, and SPM provided a second parallel copy of the same frameworks, giving the compiler two competing module definitions.

**Fix:**

Removed the direct SPM `firebase-ios-sdk` reference from `project.pbxproj` entirely — all four associated entries:

1. `PBXBuildFile` for `FirebaseMessaging in Frameworks`
2. The `FirebaseMessaging` entry in `PBXFrameworksBuildPhase`
3. The `XCRemoteSwiftPackageReference` block for `firebase-ios-sdk`
4. The `XCSwiftPackageProductDependency` block for `FirebaseMessaging`

CocoaPods is now the **sole** integration point for Firebase. The `@react-native-firebase/messaging` pod already pulls in `FirebaseMessaging` as a transitive dependency via CocoaPods, so the SPM reference was entirely redundant.

---

### Why All Three Layers Had to Be Fixed

Fixing Layer 1 alone (disabling `CLANG_ENABLE_EXPLICIT_MODULES`) suppressed the initial `redefinition` error but unmasked the SPM version mismatch error underneath. Fixing Layer 2 (CocoaPods upgrade) was necessary for stable xcconfig generation. Only after fixing Layer 3 (removing the duplicate SPM reference) did the build succeed, because it eliminated the duplicate module loading at the source.

---

## Files Changed

| File | Change |
|---|---|
| `apps/mobile/src/screens/ShortTermForecastScreen.tsx` | Replace `navigation.navigate('Profile')` with `Alert.alert`; close modal on success |
| `apps/mobile/ios/Podfile` | Add `$FirebaseSDKVersion = '12.10.0'`; add `CLANG_ENABLE_EXPLICIT_MODULES = NO` and `DEFINES_MODULE = NO` in `post_install` |
| `apps/mobile/ios/Podfile.lock` | Regenerated after `pod install` with CocoaPods 1.16.2 |
| `apps/mobile/ios/mobile.xcodeproj/project.pbxproj` | Remove `XCRemoteSwiftPackageReference` for `firebase-ios-sdk` and all associated entries |

## Testing

- All 706 existing Jest unit/component tests pass (`pnpm test`)
- `xcodebuild` against iPhone 17 simulator (iOS 26.0): **BUILD SUCCEEDED**
- Report modal: verified modal closes in-place on success, alert shown for unauthenticated users
