### PR TITLE
Split ML and backup R2 credentials

### DIFF
--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -1,7 +1,7 @@
 name: Manual DB Backup
 
 # Principle of least privilege for the GITHUB_TOKEN — only checkout needs
-# read; backup writes go to R2 via dedicated R2_* secrets.
+# read; backup writes go to R2 via dedicated BACKUP_R2_* secrets.
 permissions:
   contents: read
 
@@ -24,8 +24,8 @@ permissions:
 #                             endpoint — transaction-mode pooling breaks
 #                             pg_dump's session-level locks)
 #   R2_ACCOUNT_ID
-#   R2_ACCESS_KEY_ID
-#   R2_SECRET_ACCESS_KEY
+#   BACKUP_R2_ACCESS_KEY_ID
+#   BACKUP_R2_SECRET_ACCESS_KEY
 #   R2_BACKUPS_BUCKET
 
 on:
@@ -106,8 +106,8 @@ jobs:
 
       - name: pg_dump → gzip → R2 (streaming)
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.BACKUP_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.BACKUP_R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
           R2_BUCKET: ${{ secrets.R2_BACKUPS_BUCKET }}
@@ -134,8 +134,8 @@ jobs:
 
       - name: Verify upload
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.BACKUP_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.BACKUP_R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
           R2_BUCKET: ${{ secrets.R2_BACKUPS_BUCKET }}

--- a/.github/workflows/ml-retrain.yml
+++ b/.github/workflows/ml-retrain.yml
@@ -103,8 +103,8 @@ jobs:
       MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}
       MLFLOW_ARTIFACT_LOCATION: ${{ secrets.MLFLOW_ARTIFACT_LOCATION }}
       R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
-      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      ML_R2_ACCESS_KEY_ID: ${{ secrets.ML_R2_ACCESS_KEY_ID }}
+      ML_R2_SECRET_ACCESS_KEY: ${{ secrets.ML_R2_SECRET_ACCESS_KEY }}
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
     defaults:
       run:
@@ -136,8 +136,8 @@ jobs:
             MLFLOW_TRACKING_URI \
             MLFLOW_ARTIFACT_LOCATION \
             R2_ENDPOINT_URL \
-            R2_ACCESS_KEY_ID \
-            R2_SECRET_ACCESS_KEY \
+            ML_R2_ACCESS_KEY_ID \
+            ML_R2_SECRET_ACCESS_KEY \
             R2_BUCKET; do
             if [[ -z "${!name:-}" ]]; then
               echo "::error::$name is not configured for ML retrain"

--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -18,8 +18,8 @@ permissions:
 # Required GH secrets (all required — workflow fails loudly if any are missing):
 #   NEON_API_KEY
 #   R2_ACCOUNT_ID
-#   R2_ACCESS_KEY_ID
-#   R2_SECRET_ACCESS_KEY
+#   BACKUP_R2_ACCESS_KEY_ID
+#   BACKUP_R2_SECRET_ACCESS_KEY
 #   R2_BACKUPS_BUCKET         (value: "sharkpark-backups")
 # Required GH vars:
 #   NEON_PROJECT_ID
@@ -46,16 +46,16 @@ jobs:
           NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          BACKUP_R2_ACCESS_KEY_ID: ${{ secrets.BACKUP_R2_ACCESS_KEY_ID }}
+          BACKUP_R2_SECRET_ACCESS_KEY: ${{ secrets.BACKUP_R2_SECRET_ACCESS_KEY }}
           R2_BACKUPS_BUCKET: ${{ secrets.R2_BACKUPS_BUCKET }}
         run: |
           missing=()
           [ -z "$NEON_PROJECT_ID" ]      && missing+=("vars.NEON_PROJECT_ID")
           [ -z "$NEON_API_KEY" ]         && missing+=("secrets.NEON_API_KEY")
           [ -z "$R2_ACCOUNT_ID" ]        && missing+=("secrets.R2_ACCOUNT_ID")
-          [ -z "$R2_ACCESS_KEY_ID" ]     && missing+=("secrets.R2_ACCESS_KEY_ID")
-          [ -z "$R2_SECRET_ACCESS_KEY" ] && missing+=("secrets.R2_SECRET_ACCESS_KEY")
+          [ -z "$BACKUP_R2_ACCESS_KEY_ID" ]     && missing+=("secrets.BACKUP_R2_ACCESS_KEY_ID")
+          [ -z "$BACKUP_R2_SECRET_ACCESS_KEY" ] && missing+=("secrets.BACKUP_R2_SECRET_ACCESS_KEY")
           [ -z "$R2_BACKUPS_BUCKET" ]    && missing+=("secrets.R2_BACKUPS_BUCKET")
           if [ ${#missing[@]} -gt 0 ]; then
             echo "ERROR: Required configuration is missing: ${missing[*]}" >&2
@@ -103,8 +103,8 @@ jobs:
       - name: Locate latest backup in R2
         id: dump
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.BACKUP_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.BACKUP_R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
           BUCKET: ${{ secrets.R2_BACKUPS_BUCKET }}

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -92,3 +92,17 @@ AWS_REGION="us-west-2"
 AWS_ACCESS_KEY_ID="local"
 AWS_SECRET_ACCESS_KEY="local"
 S3_ENDPOINT="http://localhost:4566"
+
+# ─── Production backups (Cloudflare R2) ────────────────────────────────
+R2_ACCOUNT_ID=""
+BACKUP_R2_ACCESS_KEY_ID=""
+BACKUP_R2_SECRET_ACCESS_KEY=""
+R2_BACKUPS_BUCKET="sharkpark-backups"
+
+# ─── Production ML artifacts (Cloudflare R2 + MLflow) ──────────────────
+R2_ENDPOINT_URL="https://<account-id>.r2.cloudflarestorage.com"
+ML_R2_ACCESS_KEY_ID=""
+ML_R2_SECRET_ACCESS_KEY=""
+R2_BUCKET="sharkpark-ml-exports"
+MLFLOW_TRACKING_URI=""
+MLFLOW_ARTIFACT_LOCATION="s3://sharkpark-ml-exports/mlflow-artifacts"

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -76,8 +76,10 @@ src/
 The canonical, fully-commented reference is [`.env.example`](.env.example).
 Required for production: `DATABASE_URL`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,
 `DEVICE_HASH_SALT`, `DEVICE_EVENT_SECRET`, `WS_CONNECT_SECRET`, `REDIS_URL`,
-`CORS_ORIGINS`, plus the R2 credentials (`AWS_*` + `S3_ENDPOINT`) used by the
-backup and ML-export jobs. Sentry, Firebase, and weather overrides are
+`CORS_ORIGINS`, plus the backup R2 credentials (`R2_ACCOUNT_ID`,
+`BACKUP_R2_ACCESS_KEY_ID`, `BACKUP_R2_SECRET_ACCESS_KEY`, `R2_BACKUPS_BUCKET`)
+and ML R2 credentials (`R2_ENDPOINT_URL`, `ML_R2_ACCESS_KEY_ID`,
+`ML_R2_SECRET_ACCESS_KEY`). Sentry, Firebase, and weather overrides are
 optional and degrade gracefully when unset (logged as warnings).
 
 ## Operations

--- a/apps/backend/src/scheduler/jobs/_ml-runner.ts
+++ b/apps/backend/src/scheduler/jobs/_ml-runner.ts
@@ -52,7 +52,7 @@ export function spawnPythonModule(
   return new Promise((resolve, reject) => {
     const child = spawn(ML_PYTHON, ['-u', '-m', moduleName, ...args], {
       cwd: ML_WORKDIR,
-      // Inherit parent env (DATABASE_URL, MLFLOW_*, R2_*, AWS_*) so
+      // Inherit parent env (DATABASE_URL, MLFLOW_*, ML_R2_*, AWS_*) so
       // mlflow_setup.configure_mlflow() picks up the prod tracking URI.
       env: { ...process.env, ...options.env },
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/apps/backend/src/scheduler/jobs/backup-db.job.spec.ts
+++ b/apps/backend/src/scheduler/jobs/backup-db.job.spec.ts
@@ -21,8 +21,8 @@ import { BackupDbJob } from './backup-db.job';
 const REQUIRED_ENV = {
   DIRECT_URL: 'postgres://u:p@host/db',
   R2_ACCOUNT_ID: 'acct',
-  R2_ACCESS_KEY_ID: 'ak',
-  R2_SECRET_ACCESS_KEY: 'sk',
+  BACKUP_R2_ACCESS_KEY_ID: 'ak',
+  BACKUP_R2_SECRET_ACCESS_KEY: 'sk',
   R2_BACKUPS_BUCKET: 'bucket',
 };
 

--- a/apps/backend/src/scheduler/jobs/backup-db.job.ts
+++ b/apps/backend/src/scheduler/jobs/backup-db.job.ts
@@ -19,7 +19,8 @@ const NAME = 'backup-db';
  * keeps memory bounded regardless of dump size.
  *
  * Required env (Fly secrets):
- *   DIRECT_URL, R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY,
+ *   DIRECT_URL, R2_ACCOUNT_ID, BACKUP_R2_ACCESS_KEY_ID,
+ *   BACKUP_R2_SECRET_ACCESS_KEY,
  *   R2_BACKUPS_BUCKET
  */
 @Injectable()
@@ -34,13 +35,13 @@ export class BackupDbJob {
     await this.runner.run(NAME, async () => {
       const dbUrl = process.env.DIRECT_URL;
       const accountId = process.env.R2_ACCOUNT_ID;
-      const accessKeyId = process.env.R2_ACCESS_KEY_ID;
-      const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
+      const accessKeyId = process.env.BACKUP_R2_ACCESS_KEY_ID;
+      const secretAccessKey = process.env.BACKUP_R2_SECRET_ACCESS_KEY;
       const bucket = process.env.R2_BACKUPS_BUCKET;
 
       if (!dbUrl || !accountId || !accessKeyId || !secretAccessKey || !bucket) {
         throw new Error(
-          `${NAME}: missing one of DIRECT_URL, R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BACKUPS_BUCKET`,
+          `${NAME}: missing one of DIRECT_URL, R2_ACCOUNT_ID, BACKUP_R2_ACCESS_KEY_ID, BACKUP_R2_SECRET_ACCESS_KEY, R2_BACKUPS_BUCKET`,
         );
       }
 

--- a/apps/backend/src/scheduler/jobs/verify-latest-backup.job.spec.ts
+++ b/apps/backend/src/scheduler/jobs/verify-latest-backup.job.spec.ts
@@ -22,8 +22,8 @@ import { VerifyLatestBackupJob } from './verify-latest-backup.job';
 
 const REQUIRED_ENV = {
   R2_ACCOUNT_ID: 'acct',
-  R2_ACCESS_KEY_ID: 'ak',
-  R2_SECRET_ACCESS_KEY: 'sk',
+  BACKUP_R2_ACCESS_KEY_ID: 'ak',
+  BACKUP_R2_SECRET_ACCESS_KEY: 'sk',
   R2_BACKUPS_BUCKET: 'bucket',
 };
 

--- a/apps/backend/src/scheduler/jobs/verify-latest-backup.job.ts
+++ b/apps/backend/src/scheduler/jobs/verify-latest-backup.job.ts
@@ -33,13 +33,13 @@ export class VerifyLatestBackupJob {
   async handle(): Promise<void> {
     await this.runner.run(NAME, async () => {
       const accountId = process.env.R2_ACCOUNT_ID;
-      const accessKeyId = process.env.R2_ACCESS_KEY_ID;
-      const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
+      const accessKeyId = process.env.BACKUP_R2_ACCESS_KEY_ID;
+      const secretAccessKey = process.env.BACKUP_R2_SECRET_ACCESS_KEY;
       const bucket = process.env.R2_BACKUPS_BUCKET;
 
       if (!accountId || !accessKeyId || !secretAccessKey || !bucket) {
         throw new Error(
-          `${NAME}: missing R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, or R2_BACKUPS_BUCKET`,
+          `${NAME}: missing R2_ACCOUNT_ID, BACKUP_R2_ACCESS_KEY_ID, BACKUP_R2_SECRET_ACCESS_KEY, or R2_BACKUPS_BUCKET`,
         );
       }
 

--- a/docs/PRE_LAUNCH_AUDIT.md
+++ b/docs/PRE_LAUNCH_AUDIT.md
@@ -171,7 +171,7 @@ The "30 vs 90" suspicion likely reflected confusion between **30d events** (raw 
 ### 🔴 HIGH — must fix before deployment
 
 1. **`restore-test.yml` graceful-skip gates** ([.github/workflows/restore-test.yml](../.github/workflows/restore-test.yml)). ✅ **Fixed.**
-   - Removed `if: ${{ vars.NEON_PROJECT_ID != '' }}` and the `R2_*` env-check exit-0 path. The workflow now requires `NEON_PROJECT_ID`, `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BACKUPS_BUCKET` and fails loudly when any are missing.
+   - Removed `if: ${{ vars.NEON_PROJECT_ID != '' }}` and the R2 env-check exit-0 path. The workflow now requires `NEON_PROJECT_ID`, `R2_ACCOUNT_ID`, `BACKUP_R2_ACCESS_KEY_ID`, `BACKUP_R2_SECRET_ACCESS_KEY`, `R2_BACKUPS_BUCKET` and fails loudly when any are missing.
 
 2. **`.env.example` placeholder secrets.** ✅ **Fixed.**
    - Removed all placeholder values (`replace-me-with-openssl-rand-hex-32`, blanks) for `DEVICE_HASH_SALT`, `DEVICE_EVENT_SECRET`, `WS_CONNECT_SECRET`, `ADMIN_API_KEY`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `DATABASE_URL`, `DIRECT_URL`. Added `ADMIN_API_KEY` placeholder slot. Production must set via `flyctl secrets set ...` (see §10 checklist) — there is no fallback.
@@ -196,7 +196,7 @@ The "30 vs 90" suspicion likely reflected confusion between **30d events** (raw 
 
 10. ML hyperparameters hardcoded (n_estimators=200, max_depth=6, lr=0.1). Optuna sweep deferred until ≥6 months of real data.
 11. Weather "commute hour" windows (7–9, 16–18) are hand-picked. Calibrate against arrival/departure logs once available.
-12. `predict_short_term.py` baseline boto3 test failures (6 reported pre-existing). Confirm root cause: missing R2 credentials in the test environment. Add `pytest -m "not r2"` to CI default and a separate gated job that runs R2 tests only when `R2_ACCESS_KEY_ID` is present (not as a graceful skip — as a separate matrix entry).
+12. `predict_short_term.py` baseline boto3 test failures (6 reported pre-existing). Confirm root cause: missing ML R2 credentials in the test environment. Add `pytest -m "not r2"` to CI default and a separate gated job that runs R2 tests only when `ML_R2_ACCESS_KEY_ID` is present (not as a graceful skip — as a separate matrix entry).
 13. No automated rollback for ML model promotion. Manual via `--run-id`.
 14. Cross-semester baseline lookup for long-term model (planned in `Model_Design.md`).
 
@@ -273,9 +273,9 @@ All 29 jobs:
 
 See [SYSTEM_OVERVIEW.md §6](SYSTEM_OVERVIEW.md#6-environment-variables-and-secrets) for the full table. Quick map:
 
-**Backend (Fly secrets):** `DATABASE_URL`, `DIRECT_URL`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `DEVICE_HASH_SALT`, `DEVICE_EVENT_SECRET`, `WS_CONNECT_SECRET`, `ADMIN_API_KEY`, `SENTRY_DSN`, `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`, `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BACKUPS_BUCKET`, `MLFLOW_TRACKING_URI`, `MLFLOW_ARTIFACT_LOCATION`, `R2_ENDPOINT_URL`.
+**Backend (Fly secrets):** `DATABASE_URL`, `DIRECT_URL`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `DEVICE_HASH_SALT`, `DEVICE_EVENT_SECRET`, `WS_CONNECT_SECRET`, `ADMIN_API_KEY`, `SENTRY_DSN`, `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`, `R2_ACCOUNT_ID`, `BACKUP_R2_ACCESS_KEY_ID`, `BACKUP_R2_SECRET_ACCESS_KEY`, `R2_BACKUPS_BUCKET`, `ML_R2_ACCESS_KEY_ID`, `ML_R2_SECRET_ACCESS_KEY`, `MLFLOW_TRACKING_URI`, `MLFLOW_ARTIFACT_LOCATION`, `R2_ENDPOINT_URL`.
 
-**ML pipeline (GitHub Actions secrets):** `NEON_DATABASE_URL`, `ML_DATABASE_URL` (optional read replica), `MLFLOW_TRACKING_URI`, `MLFLOW_ARTIFACT_LOCATION`, `R2_ENDPOINT_URL`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`.
+**ML pipeline (GitHub Actions secrets):** `NEON_DATABASE_URL`, `ML_DATABASE_URL` (optional read replica), `MLFLOW_TRACKING_URI`, `MLFLOW_ARTIFACT_LOCATION`, `R2_ENDPOINT_URL`, `ML_R2_ACCESS_KEY_ID`, `ML_R2_SECRET_ACCESS_KEY`, `R2_BUCKET`.
 
 **Deploy + CI (GitHub Actions secrets):** `FLY_API_TOKEN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `NEON_API_KEY`, `NEON_PROJECT_ID` (var), `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CODECOV_TOKEN` (optional).
 
@@ -375,10 +375,12 @@ flyctl secrets set \
   FIREBASE_CLIENT_EMAIL="..." \
   FIREBASE_PRIVATE_KEY="..." \
   R2_ACCOUNT_ID="..." \
-  R2_ACCESS_KEY_ID="..." \
-  R2_SECRET_ACCESS_KEY="..." \
+  BACKUP_R2_ACCESS_KEY_ID="..." \
+  BACKUP_R2_SECRET_ACCESS_KEY="..." \
   R2_BACKUPS_BUCKET="sharkpark-backups" \
   R2_ENDPOINT_URL="https://<account-id>.r2.cloudflarestorage.com" \
+  ML_R2_ACCESS_KEY_ID="..." \
+  ML_R2_SECRET_ACCESS_KEY="..." \
   MLFLOW_TRACKING_URI="postgresql+psycopg2://..." \
   MLFLOW_ARTIFACT_LOCATION="s3://sharkpark-ml-exports/mlflow-artifacts" \
   WEATHER_USER_AGENT="SharkPark/1.0 (ops@sharkpark.app)" \
@@ -391,7 +393,7 @@ Verify: `flyctl secrets list`. There should be no `replace-me-*` placeholders.
 
 Required (deploy will fail without these — that is intentional):
 
-`FLY_API_TOKEN`, `NEON_DATABASE_URL`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `NEON_API_KEY` + `NEON_PROJECT_ID` (var), `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BACKUPS_BUCKET`, `R2_ENDPOINT_URL`, `R2_BUCKET`, `MLFLOW_TRACKING_URI`, `MLFLOW_ARTIFACT_LOCATION`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`.
+`FLY_API_TOKEN`, `NEON_DATABASE_URL`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `NEON_API_KEY` + `NEON_PROJECT_ID` (var), `R2_ACCOUNT_ID`, `BACKUP_R2_ACCESS_KEY_ID`, `BACKUP_R2_SECRET_ACCESS_KEY`, `R2_BACKUPS_BUCKET`, `R2_ENDPOINT_URL`, `R2_BUCKET`, `ML_R2_ACCESS_KEY_ID`, `ML_R2_SECRET_ACCESS_KEY`, `MLFLOW_TRACKING_URI`, `MLFLOW_ARTIFACT_LOCATION`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`.
 
 Optional: `CODECOV_TOKEN`, `ML_DATABASE_URL`.
 

--- a/docs/runbooks/restore.md
+++ b/docs/runbooks/restore.md
@@ -46,8 +46,8 @@ Export for the AWS CLI session:
 
 ```bash
 export R2_ACCOUNT_ID=...                # 32-char hex
-export AWS_ACCESS_KEY_ID=...
-export AWS_SECRET_ACCESS_KEY=...
+export AWS_ACCESS_KEY_ID=...            # BACKUP_R2_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=...        # BACKUP_R2_SECRET_ACCESS_KEY
 export AWS_DEFAULT_REGION=auto
 ```
 

--- a/services/ml/.env.example
+++ b/services/ml/.env.example
@@ -13,7 +13,7 @@ DATABASE_URL=postgresql://sharkpark:sharkpark@localhost:5433/sharkpark
 MLFLOW_TRACKING_URI=postgresql+psycopg2://mlflow:<pw>@<host>/sharkpark_mlflow?sslmode=require
 
 # Where MLflow writes run artifacts (models, plots, parquet snapshots). Combined
-# with R2_* below this lands in Cloudflare R2 via boto3's S3-compatible client.
+# with ML_R2_* below this lands in Cloudflare R2 via boto3's S3-compatible client.
 MLFLOW_ARTIFACT_LOCATION=s3://sharkpark-ml-exports/mlflow-artifacts
 
 # ── Cloudflare R2 (model artifact store + MLflow artifact store) ────────
@@ -21,10 +21,10 @@ MLFLOW_ARTIFACT_LOCATION=s3://sharkpark-ml-exports/mlflow-artifacts
 # AND by MLflow itself (mirrored into AWS_*/MLFLOW_S3_ENDPOINT_URL by
 # src/utils/mlflow_setup.py at process start).
 # Endpoint URL: Cloudflare dashboard → R2 → bucket → Settings → "S3 API".
-# Token must have Object Read & Write permission on the bucket.
+# Token must have Object Read & Write permission on sharkpark-ml-exports.
 R2_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
-R2_ACCESS_KEY_ID=
-R2_SECRET_ACCESS_KEY=
+ML_R2_ACCESS_KEY_ID=
+ML_R2_SECRET_ACCESS_KEY=
 # R2_BUCKET=sharkpark-ml-exports   # optional; default shown
 
 # ── Optional toggles ────────────────────────────────────

--- a/services/ml/src/utils/mlflow_setup.py
+++ b/services/ml/src/utils/mlflow_setup.py
@@ -32,9 +32,11 @@ backend store and artifact root.
   read+write on the bucket. We deliberately reuse the AWS_* names because the
   ``boto3`` client MLflow uses internally only reads those.
 
-If ``R2_*`` env vars are set (e.g. carried over from earlier dev), this module
-mirrors them into the ``AWS_*``/``MLFLOW_S3_ENDPOINT_URL`` variables MLflow
-expects, so a single source of truth in ``.env`` works for both code paths.
+If ``ML_R2_*`` env vars are set, this module mirrors them into the
+``AWS_*``/``MLFLOW_S3_ENDPOINT_URL`` variables MLflow expects. Legacy ``R2_*``
+names are still accepted as a local-dev fallback, but production should use
+``ML_R2_ACCESS_KEY_ID`` and ``ML_R2_SECRET_ACCESS_KEY`` so backup credentials
+can stay isolated.
 """
 
 from __future__ import annotations
@@ -53,22 +55,25 @@ _CONFIGURED = False
 
 
 def _mirror_r2_to_aws_env() -> None:
-    """Mirror R2_* env vars to the AWS_*/MLFLOW_S3_* names boto3 expects.
+    """Mirror ML_R2_* env vars to the AWS_*/MLFLOW_S3_* names boto3 expects.
 
     No-op for any name that is already explicitly set, so explicit AWS_* values
-    always win. This lets a single ``.env`` with R2_* vars work for both the
-    legacy ``upload_model_to_r2`` path (which reads R2_*) and MLflow's S3
-    artifact client (which reads AWS_*).
+    always win. Legacy R2_* names are accepted after ML_R2_* to avoid breaking
+    existing local .env files during the credential split.
     """
     pairs = (
-        ("R2_ACCESS_KEY_ID", "AWS_ACCESS_KEY_ID"),
-        ("R2_SECRET_ACCESS_KEY", "AWS_SECRET_ACCESS_KEY"),
-        ("R2_ENDPOINT_URL", "MLFLOW_S3_ENDPOINT_URL"),
+        (("ML_R2_ACCESS_KEY_ID", "R2_ACCESS_KEY_ID"), "AWS_ACCESS_KEY_ID"),
+        (("ML_R2_SECRET_ACCESS_KEY", "R2_SECRET_ACCESS_KEY"), "AWS_SECRET_ACCESS_KEY"),
+        (("ML_R2_ENDPOINT_URL", "R2_ENDPOINT_URL"), "MLFLOW_S3_ENDPOINT_URL"),
     )
-    for src, dst in pairs:
-        src_val = os.environ.get(src)
-        if src_val and not os.environ.get(dst):
-            os.environ[dst] = src_val
+    for sources, dst in pairs:
+        if os.environ.get(dst):
+            continue
+        for src in sources:
+            src_val = os.environ.get(src)
+            if src_val:
+                os.environ[dst] = src_val
+                break
 
     # boto3 also requires a region; R2 ignores it but the SDK refuses to sign
     # without one. ``auto`` is the conventional value for R2.

--- a/services/ml/src/utils/mlflow_utils.py
+++ b/services/ml/src/utils/mlflow_utils.py
@@ -201,22 +201,30 @@ def _upload_to_r2(model_name: str, version: str, run_id: str) -> None:
     Downloads the run's `model` artifact directory from MLflow, uploads each file
     to ``s3://<bucket>/models/<model_name>/<version>/<filename>``
 
-    Required env vars: R2_ENDPOINT_URL, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY.
+    Required env vars: R2_ENDPOINT_URL, ML_R2_ACCESS_KEY_ID,
+    ML_R2_SECRET_ACCESS_KEY. Legacy R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY are
+    accepted as local-dev fallbacks.
     Optional: R2_BUCKET (defaults to ``sharkpark-ml-exports``).
     """
     import boto3
 
-    endpoint_url = os.environ.get("R2_ENDPOINT_URL")
-    access_key = os.environ.get("R2_ACCESS_KEY_ID")
-    secret_key = os.environ.get("R2_SECRET_ACCESS_KEY")
+    endpoint_url = os.environ.get("ML_R2_ENDPOINT_URL") or os.environ.get(
+        "R2_ENDPOINT_URL"
+    )
+    access_key = os.environ.get("ML_R2_ACCESS_KEY_ID") or os.environ.get(
+        "R2_ACCESS_KEY_ID"
+    )
+    secret_key = os.environ.get("ML_R2_SECRET_ACCESS_KEY") or os.environ.get(
+        "R2_SECRET_ACCESS_KEY"
+    )
     bucket = os.environ.get("R2_BUCKET") or _DEFAULT_R2_BUCKET
 
     missing = [
         name
         for name, val in (
             ("R2_ENDPOINT_URL", endpoint_url),
-            ("R2_ACCESS_KEY_ID", access_key),
-            ("R2_SECRET_ACCESS_KEY", secret_key),
+            ("ML_R2_ACCESS_KEY_ID", access_key),
+            ("ML_R2_SECRET_ACCESS_KEY", secret_key),
         )
         if not val
     ]

--- a/services/ml/tests/utils/test_mlflow_utils.py
+++ b/services/ml/tests/utils/test_mlflow_utils.py
@@ -36,8 +36,8 @@ def trained_run_id(data_parquet):
 @pytest.fixture()
 def r2_env(monkeypatch):
     monkeypatch.setenv("R2_ENDPOINT_URL", "https://fake.r2.cloudflarestorage.com")
-    monkeypatch.setenv("R2_ACCESS_KEY_ID", "test-key")
-    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test-secret")
+    monkeypatch.setenv("ML_R2_ACCESS_KEY_ID", "test-key")
+    monkeypatch.setenv("ML_R2_SECRET_ACCESS_KEY", "test-secret")
     monkeypatch.setenv("R2_BUCKET", "test-bucket")
 
 
@@ -110,7 +110,13 @@ class TestR2Upload:
     ):
         """Missing R2 credentials log a warning but mlflow promotion still succeeds."""
         # Ensure no R2 env vars are set
-        for var in ("R2_ENDPOINT_URL", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY"):
+        for var in (
+            "R2_ENDPOINT_URL",
+            "ML_R2_ACCESS_KEY_ID",
+            "ML_R2_SECRET_ACCESS_KEY",
+            "R2_ACCESS_KEY_ID",
+            "R2_SECRET_ACCESS_KEY",
+        ):
             monkeypatch.delenv(var, raising=False)
 
         with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
## Summary
- move ML retrain and MLflow artifact export to ML_R2_ACCESS_KEY_ID / ML_R2_SECRET_ACCESS_KEY
- move backup and restore workflows plus backend backup cron to BACKUP_R2_ACCESS_KEY_ID / BACKUP_R2_SECRET_ACCESS_KEY
- keep legacy R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY as ML local-dev fallbacks only
- update env examples, runbooks, and tests for the split

## Required secret updates before/with merge
GitHub Actions:
- ML_R2_ACCESS_KEY_ID / ML_R2_SECRET_ACCESS_KEY for sharkpark-ml-exports
- BACKUP_R2_ACCESS_KEY_ID / BACKUP_R2_SECRET_ACCESS_KEY for sharkpark-backups

Fly backend secrets:
- ML_R2_ACCESS_KEY_ID / ML_R2_SECRET_ACCESS_KEY for prediction cron MLflow access
- BACKUP_R2_ACCESS_KEY_ID / BACKUP_R2_SECRET_ACCESS_KEY for backup cron

Existing R2_ENDPOINT_URL, R2_ACCOUNT_ID, R2_BUCKET, and R2_BACKUPS_BUCKET remain in use.

## Verification
- git diff --check
- YAML parse check for ml-retrain, backup-db, restore-test
- pnpm --filter @sharkpark/backend test -- backup-db.job.spec.ts verify-latest-backup.job.spec.ts --runInBand
- pnpm --filter @sharkpark/backend typecheck
- pnpm --filter @sharkpark/backend lint
- env UV_CACHE_DIR=/private/tmp/sharkpark-uv-cache uv run ruff check src/utils/mlflow_setup.py src/utils/mlflow_utils.py tests/utils/test_mlflow_utils.py
- env UV_CACHE_DIR=/private/tmp/sharkpark-uv-cache uv run pytest tests/utils/test_mlflow_utils.py -q
- pre-commit lint and typecheck hooks passed during commit