### PR TITLE
ci(ml): make retrain workflow cold-start ready

### DIFF
--- a/.github/workflows/ml-retrain.yml
+++ b/.github/workflows/ml-retrain.yml
@@ -48,6 +48,21 @@ on:
         required: true
         type: boolean
         default: true
+      include_synthetic_v2:
+        description: 'Blend catalog-driven synthetic v2 rows from synthetic_observations'
+        required: false
+        type: boolean
+        default: false
+      synthetic_v2_school:
+        description: 'School short_name for v2 loader (required when include_synthetic_v2=true)'
+        required: false
+        type: string
+        default: 'CSULB'
+      synthetic_v2_term:
+        description: 'Term filter for v2 loader (e.g. Spring_2026; leave blank to load all terms for the school)'
+        required: false
+        type: string
+        default: ''
 
 # Per-horizon mutex — only one short-term retrain at a time, only one
 # long-term retrain at a time. `cancel-in-progress: false` because we
@@ -166,19 +181,84 @@ jobs:
       - name: Verify MLflow + R2 connectivity (bootstrap)
         run: uv run python -m scripts.bootstrap_mlflow
 
-      - name: Train (${{ matrix.horizon }})
-        id: train
+      - name: Generate synthetic v1 priors
+        # The 4-tier sample-weighting scheme blends synthetic v1 priors with
+        # real cold-start + established rows. Parquets are not committed to the
+        # repo (regenerated each run from the lot catalog in Postgres). We
+        # generate the current and prior semesters so the glob
+        # ``data/synthetic_*.parquet`` always matches at least one file.
         run: |
           set -euo pipefail
+          mkdir -p data
+          # Pick current + previous semester from today's UTC date. Spring runs
+          # Jan-May, Fall runs Aug-Dec. Summer (Jun-Jul) falls back to the most
+          # recent spring + previous fall.
+          YEAR=$(date -u +%Y)
+          MONTH=$(date -u +%m)
+          MONTH=$((10#$MONTH))
+          if (( MONTH >= 8 )); then
+            CURRENT="fall-${YEAR}"
+            PREVIOUS="spring-${YEAR}"
+          elif (( MONTH >= 1 && MONTH <= 5 )); then
+            CURRENT="spring-${YEAR}"
+            PREVIOUS="fall-$((YEAR - 1))"
+          else
+            # Summer: no active semester, use most recent two
+            CURRENT="spring-${YEAR}"
+            PREVIOUS="fall-$((YEAR - 1))"
+          fi
+          echo "Generating synthetic v1 priors for $PREVIOUS and $CURRENT"
+          uv run python -m src.data.synthetic --semester "$PREVIOUS"
+          uv run python -m src.data.synthetic --semester "$CURRENT"
+          ls -lh data/synthetic_*.parquet
+
+      - name: Train (${{ matrix.horizon }})
+        id: train
+        # Tier weights match the D5 launch spec in services/ml/Model_Design.md:
+        #   --real-weight 10 --synthetic-v2-weight 1 --synthetic-weight 0.1
+        # The CLI defaults are 1.0 across the board for backward-compat with
+        # ad-hoc local training; we have to pass them explicitly here so the
+        # automated retrain matches the documented behavior.
+        #
+        # --include-synthetic-v2 is opt-in via workflow_dispatch only — the
+        # scheduled cron stays on v1+real because v2 depends on the catalog
+        # ingest (D2) + proximity build (D3) + a generate-synthetic-v2 run
+        # having been completed for the active term. Flip it on manually once
+        # those upstream pipelines have produced rows for the term.
+        env:
+          INCLUDE_V2: ${{ github.event_name == 'workflow_dispatch' && inputs.include_synthetic_v2 || 'false' }}
+          V2_SCHOOL: ${{ github.event_name == 'workflow_dispatch' && inputs.synthetic_v2_school || '' }}
+          V2_TERM: ${{ github.event_name == 'workflow_dispatch' && inputs.synthetic_v2_term || '' }}
+        run: |
+          set -euo pipefail
+          V2_ARGS=()
+          if [[ "${INCLUDE_V2:-false}" == "true" ]]; then
+            if [[ -z "${V2_SCHOOL:-}" ]]; then
+              echo "::error::synthetic_v2_school is required when include_synthetic_v2=true"
+              exit 1
+            fi
+            V2_ARGS+=(--include-synthetic-v2 --synthetic-v2-school "$V2_SCHOOL")
+            if [[ -n "${V2_TERM:-}" ]]; then
+              V2_ARGS+=(--synthetic-v2-term "$V2_TERM")
+            fi
+          fi
           if [[ "${{ matrix.horizon }}" == "short-term" ]]; then
             uv run python -m scripts.train_short_term \
               --include-real \
               --real-start-date "$(date -u -d '90 days ago' +%Y-%m-%d)" \
+              --real-weight 10.0 \
+              --synthetic-v2-weight 1.0 \
+              --synthetic-weight 0.1 \
+              "${V2_ARGS[@]}" \
               | tee train.log
           else
             uv run python -m scripts.train_long_term \
               --include-real \
               --real-start-date "$(date -u -d '180 days ago' +%Y-%m-%d)" \
+              --real-weight 10.0 \
+              --synthetic-v2-weight 1.0 \
+              --synthetic-weight 0.1 \
+              "${V2_ARGS[@]}" \
               | tee train.log
           fi
           # train_*.py logs the candidate run id in the format


### PR DESCRIPTION
## Why

We need to do a cold-start production deploy mid-Spring 2026 (current semester is in flight, no model has ever been promoted to `@production`). When I tried `gh workflow run ml-retrain.yml` against `main`, it failed before training even started:

```
FileNotFoundError: data/synthetic_*.parquet
```

A full audit of `services/ml/` + `apps/backend/src/scheduler/` + the existing workflows surfaced three gaps that have to be fixed before scheduled retrains can produce a usable launch model.

## What this PR changes

All three changes are confined to `.github/workflows/ml-retrain.yml`. No code/script changes.

### 1. Generate synthetic v1 priors inside the job

Synthetic v1 parquets are not committed to the repo (they're a pure function of the `lots` table + the academic calendar — regenerated on every run). The trainer globs `data/synthetic_*.parquet` and dies if nothing matches, so the workflow now derives the current + previous semester from today's UTC date and runs `python -m src.data.synthetic --semester …` for each before kicking off training.

- Spring (Jan–May) → `spring-<YYYY>` + `fall-<YYYY-1>`
- Fall (Aug–Dec) → `fall-<YYYY>` + `spring-<YYYY>`
- Summer (Jun–Jul) falls back to most recent two semesters

### 2. Pass the D5 spec tier weights explicitly

The `train_short_term.py` / `train_long_term.py` CLIs default every `--*-weight` to `1.0` for backward-compat with ad-hoc local training, with a comment noting the actual launch spec from `services/ml/Model_Design.md` is:

```
--real-weight 10
--synthetic-v2-weight 1
--synthetic-weight 0.1
```

The scheduled retrain wasn't passing any of these flags, so production training silently ran with `1.0/1.0/1.0/1.0` and treated 8-month-old synthetic priors the same as last week's real snapshots. Pass the spec values explicitly to both the short-term and long-term train invocations.

### 3. Opt-in synthetic v2 via `workflow_dispatch` inputs

v2 (catalog-driven `synthetic_observations`) requires the catalog ingest (D2), proximity build (D3), and a `generate-synthetic-v2.yml` run for the active term to produce rows. Until those upstream pipelines are warm, v2 has to stay off in scheduled retrains — but it should be easy to flip on manually once we're ready.

Adds three `workflow_dispatch` inputs (default off, all empty):

- `include_synthetic_v2` (bool, default `false`)
- `synthetic_v2_school` (string, default `CSULB`)
- `synthetic_v2_term` (string, default empty — loads all terms for the school when omitted)

When enabled, the train step appends `--include-synthetic-v2 --synthetic-v2-school <X> [--synthetic-v2-term <Y>]`. The step fails loudly (`exit 1`) if v2 is requested without a school — no silent skip.

## Cold-start deploy sequence (post-merge)

1. Confirm the 7 ML secrets are set in repo + Fly: `DATABASE_URL` (or `ML_DATABASE_URL`), `MLFLOW_TRACKING_URI`, `MLFLOW_ARTIFACT_LOCATION`, `R2_ENDPOINT_URL`, `ML_R2_ACCESS_KEY_ID`, `ML_R2_SECRET_ACCESS_KEY`, `R2_BUCKET`. The R2 token+secret were derived in #220.
2. `gh workflow run ml-retrain.yml -f horizon=both -f auto_promote=true` — this now bootstraps MLflow → generates v1 priors for `spring-2026` + `fall-2025` → trains both horizons → runs the promotion guard → exports to `s3://sharkpark-ml-exports/models/<name>/<version>/` on success.
3. Verify the R2 export landed (one `model.json`, two quantile bound files, `metadata.joblib`, plus the `production.json` pointer).
4. Backend predict crons pick up the new `@production` alias automatically — short-term within 15 min (`5,20,35,50 * * * *`), long-term at the next `01:05 PT` tick. The cron-monitors layer already swallows the `RuntimeError("No production model found …")` cleanly, so there's no risk of crashing the API while the model is being trained.
5. v2 stays off for this first launch. Once the catalog/proximity/v2-gen pipelines have produced rows for `Spring_2026`, re-trigger with `-f include_synthetic_v2=true -f synthetic_v2_term=Spring_2026`.

## Out of scope

- No changes to `train_short_term.py` / `train_long_term.py` defaults — keeping `1.0` defaults preserves the documented backward-compat for local ad-hoc training.
- No changes to `generate-synthetic-v2.yml` (still manual-only — intentional, since v2 only changes when upstream catalog data does).
- No new docs file — cold-start procedure is captured here in the PR body and in the existing `services/ml/Model_Design.md` D5 section.
