### PR TITLE
fix(mobile): lock portrait orientation + fix onboarding scroll on smaller devices

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -138,6 +138,7 @@
       android:label="@string/app_name"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
       android:launchMode="singleTask"
+      android:screenOrientation="portrait"
       android:windowSoftInputMode="adjustResize"
       android:exported="true"
       android:theme="@style/BootTheme">

--- a/apps/mobile/ios/mobile/Info.plist
+++ b/apps/mobile/ios/mobile/Info.plist
@@ -122,8 +122,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/apps/mobile/src/screens/OnboardingScreen.tsx
+++ b/apps/mobile/src/screens/OnboardingScreen.tsx
@@ -20,6 +20,7 @@ import {
   View,
   StyleSheet,
   FlatList,
+  ScrollView,
   TouchableOpacity,
   Dimensions,
   Platform,
@@ -105,37 +106,43 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
 
   const renderSlide = useCallback(({ item }: { item: Slide }) => (
     <View style={styles.slide}>
-      {item.emoji === null ? (
-        <Image
-          source={sharkParkLogo}
-          style={styles.logo}
-          resizeMode="contain"
-        />
-      ) : (
-        <Text style={styles.emoji}>{item.emoji}</Text>
-      )}
-      <Text style={styles.title}>{item.title}</Text>
-      <Text style={styles.body}>{item.body}</Text>
-      {item.bullets ? (
-        <View style={styles.bulletList}>
-          {item.bullets.map((point) => (
-            <View key={point.text} style={styles.bulletRow}>
-              <Icon
-                name={point.icon}
-                size={18}
-                color={point.icon.startsWith('checkmark') ? '#10b981' : COLORS.mediumGray}
-                style={styles.bulletIcon}
-              />
-              <Text style={styles.bulletText}>{point.text}</Text>
-            </View>
-          ))}
-        </View>
-      ) : null}
-      {item.note ? (
-        <View style={styles.noteBox}>
-          <Text style={styles.noteText}>{item.note}</Text>
-        </View>
-      ) : null}
+      <ScrollView
+        contentContainerStyle={styles.slideContent}
+        showsVerticalScrollIndicator={false}
+        bounces={false}
+      >
+        {item.emoji === null ? (
+          <Image
+            source={sharkParkLogo}
+            style={styles.logo}
+            resizeMode="contain"
+          />
+        ) : (
+          <Text style={styles.emoji}>{item.emoji}</Text>
+        )}
+        <Text style={styles.title}>{item.title}</Text>
+        <Text style={styles.body}>{item.body}</Text>
+        {item.bullets ? (
+          <View style={styles.bulletList}>
+            {item.bullets.map((point) => (
+              <View key={point.text} style={styles.bulletRow}>
+                <Icon
+                  name={point.icon}
+                  size={18}
+                  color={point.icon.startsWith('checkmark') ? '#10b981' : COLORS.mediumGray}
+                  style={styles.bulletIcon}
+                />
+                <Text style={styles.bulletText}>{point.text}</Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+        {item.note ? (
+          <View style={styles.noteBox}>
+            <Text style={styles.noteText}>{item.note}</Text>
+          </View>
+        ) : null}
+      </ScrollView>
     </View>
   ), []);
 
@@ -219,9 +226,13 @@ const styles = StyleSheet.create({
   slide: {
     width: SCREEN_WIDTH,
     flex: 1,
+  },
+  slideContent: {
+    flexGrow: 1,
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: SPACING.xxxl,
+    paddingVertical: SPACING.xl,
   },
   emoji: {
     fontSize: 72,


### PR DESCRIPTION
Portrait Lock
iOS (Info.plist) — removed UIInterfaceOrientationLandscapeLeft and UIInterfaceOrientationLandscapeRight. Portrait only.

Android (AndroidManifest.xml) — added android:screenOrientation="portrait" to MainActivity. This is the standard Android way to lock orientation; configChanges stays as-is (it handles config events like keyboard/UI mode, separate from the orientation lock).

Onboarding Scroll Fix
OnboardingScreen.tsx — each slide's content is now inside a ScrollView with flexGrow: 1 + justifyContent: 'center'. On a tall screen like iPhone 17 nothing changes visually (content centers naturally). On a short screen like iPhone 15 the user can scroll down to see the note box and bullets without anything being clipped.