### PR TITLE
fix(mobile): keyboard avoidance and disable backdrop dismiss in Repor…

### DIFF
--- a/apps/mobile/src/components/Modals/ReportModal.tsx
+++ b/apps/mobile/src/components/Modals/ReportModal.tsx
@@ -4,6 +4,8 @@ import {
   TouchableOpacity,
   ScrollView, StyleSheet,
   ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { Text } from '../CustomText';
 import { TextInput } from '../CustomTextInput';
@@ -101,13 +103,11 @@ export function ReportModal({ lotDisplayName, isOpen, onClose, onSubmit }: Repor
       onRequestClose={handleClose}
     >
       <View style={styles.backdrop}>
-        <TouchableOpacity 
-          style={styles.backdropTouchable}
-          activeOpacity={1}
-          onPress={handleClose}
-        />
-        
-        <View style={styles.modal}>
+        <KeyboardAvoidingView
+          style={styles.modal}
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          keyboardVerticalOffset={Platform.OS === 'ios' ? 20 : 0}
+        >
           {/* Modal Header */}
           <View style={styles.header}>
             <View>
@@ -125,7 +125,7 @@ export function ReportModal({ lotDisplayName, isOpen, onClose, onSubmit }: Repor
           </View>
 
           {/* Modal Content */}
-          <ScrollView style={styles.content} contentContainerStyle={styles.contentContainer}>
+          <ScrollView style={styles.content} contentContainerStyle={styles.contentContainer} keyboardShouldPersistTaps="handled">
             {/* Incident Type Selection */}
             <View style={styles.section}>
               <Text style={styles.label}>Select Incident Type</Text>
@@ -212,7 +212,7 @@ export function ReportModal({ lotDisplayName, isOpen, onClose, onSubmit }: Repor
               }
             </TouchableOpacity>
           </ScrollView>
-        </View>
+        </KeyboardAvoidingView>
       </View>
     </Modal>
   );


### PR DESCRIPTION
## Summary

Fixes two UX bugs in the `ReportModal` (the incident report flow accessible from the Short-Term Forecast screen).

---

## Changes

### 1. Keyboard avoidance — custom text input no longer hidden behind keyboard

When a user selects **"Other"** and taps the text area to start typing, the modal card now shifts up so the input stays visible above the keyboard.

**Root cause:** The modal card was a plain `View` with no keyboard avoidance, so the system keyboard would slide over the `TextInput` without moving any content.

**Fix:**
- Replaced the inner modal `View` with `KeyboardAvoidingView` (`padding` on iOS, `height` on Android)
- Added `keyboardShouldPersistTaps="handled"` to the inner `ScrollView` so taps on type buttons still register while the keyboard is open

### 2. Backdrop tap no longer dismisses the modal

Tapping outside the modal card previously closed the entire report flow (navigating back to the Short-Term Forecast screen), which was unintended — especially disruptive mid-fill.

**Root cause:** An absolutely-positioned `TouchableOpacity` covered the full backdrop and called `handleClose` on press.

**Fix:** Removed the backdrop `TouchableOpacity`. The modal can now only be dismissed via the **✕ close button** in the header or the **Android hardware back button**.

---

## Files Changed

| File | Change |
|---|---|
| `apps/mobile/src/components/Modals/ReportModal.tsx` | `KeyboardAvoidingView` wrap, `keyboardShouldPersistTaps`, removed backdrop dismiss |

---

## Testing

- [ ] Select **"Other"** → tap text area → keyboard opens → input is visible above keyboard (iOS)
- [ ] Select **"Other"** → tap text area → keyboard opens → input is visible above keyboard (Android)
- [ ] Tap outside the modal card → modal stays open
- [ ] Tap **✕** → modal closes and resets state
- [ ] Android hardware back button → modal closes
- [ ] Submit flow (all three types) still works end-to-end