### PR TITLE
ci: add services/ml/** to deploy path filter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ on:
     branches: [main]
     paths:
       - "apps/backend/**"
+      - "services/ml/**"
       - "packages/types/**"
       - "packages/utils/**"
       - "pnpm-lock.yaml"


### PR DESCRIPTION
## Problem

ML scripts are baked into the Docker image at build time — the Dockerfile copies `services/ml/src` and `services/ml/scripts` directly into the image. But `services/ml/**` was missing from `deploy.yml`'s path filter, so merging ML fixes to `main` silently skipped the Fly deploy, leaving the old broken image running in production.

This caused the `predict-short-term` cron (runs every 15 min) to fail continuously after `89a0926` was merged, with:
```
MlflowException: Failed to download artifacts from path 'model'
```

## Fix

Add `"services/ml/**"` to the `paths` filter in `deploy.yml`.

## Immediate Action Required

Until this PR is merged, **trigger a manual deploy** via GitHub Actions → Deploy to Fly → Run workflow (on `main`) to pick up the fix from `89a0926` and stop the production cron failures.