### PR TITLE
fix(ml): call configure_mlflow() in predict_short_term.py

### DIFF
--- a/services/ml/scripts/predict_short_term.py
+++ b/services/ml/scripts/predict_short_term.py
@@ -36,6 +36,12 @@ from src.features.short_term import prepare_inference_features
 from src.models.short_term import ShortTermModel
 from src.postprocess.weather_adjustment import apply_weather_adjustment
 from src.postprocess.low_activity_scaling import apply_low_activity_scaling
+from src.utils.mlflow_setup import configure_mlflow
+
+# Mirror ML_R2_* Fly secrets → AWS_*/MLFLOW_S3_* env vars that boto3 needs
+# when MLflow downloads artifacts from Cloudflare R2. Must happen before any
+# mlflow.artifacts call.
+configure_mlflow()
 
 CAMPUS_TZ = ZoneInfo("America/Los_Angeles")
 UTC = ZoneInfo("UTC")


### PR DESCRIPTION
## Problem

The `predict-short-term` cron was failing with:

```
botocore.exceptions.NoCredentialsError: Unable to locate credentials
```

`predict_short_term.py` never called `configure_mlflow()`, so `_mirror_r2_to_aws_env()` never ran. The Fly secrets `ML_R2_ACCESS_KEY_ID` and `ML_R2_SECRET_ACCESS_KEY` were never copied into `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `MLFLOW_S3_ENDPOINT_URL` that boto3 requires to authenticate to Cloudflare R2.

## Fix

Call `configure_mlflow()` at module top-level in `predict_short_term.py`, before any MLflow or boto3 operations.

**Note**: This commit was missing from PR #227's squash merge — it was added to the branch after the squash was initiated.