### PR TITLE
fix(ml): strip pgbouncer param from DATABASE_URL for psycopg2

### DIFF
--- a/services/ml/src/data/db.py
+++ b/services/ml/src/data/db.py
@@ -9,6 +9,7 @@ import os
 import re
 from datetime import date
 from typing import Optional
+from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
 import pandas as pd
 import psycopg2
@@ -38,11 +39,16 @@ __all__ = [
 
 
 def _get_db_url() -> str:
-    """Return the database URL, raise if not configured."""
+    """Return the database URL, stripped of PgBouncer-specific options psycopg2 rejects."""
     url = os.environ.get("DATABASE_URL", DATABASE_URL)
     if not url:
         raise RuntimeError("DATABASE_URL environment variable is required but not set.")
-    return url
+    # Neon pooled URLs include ?pgbouncer=true which psycopg2 doesn't understand.
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query, keep_blank_values=True)
+    params.pop("pgbouncer", None)
+    cleaned = parsed._replace(query=urlencode(params, doseq=True))
+    return urlunparse(cleaned)
 
 
 def _normalize_catalog_term(term: Optional[str]) -> Optional[str]:


### PR DESCRIPTION
## Summary
Fix production ML cron DB connectivity by removing Neon pooled URL query option that psycopg2 rejects.

## Problem
`DATABASE_URL` in Fly includes `?pgbouncer=true`.
- SQLAlchemy/driver path in this script ultimately reaches psycopg2
- psycopg2 raises: `ProgrammingError: invalid dsn: invalid connection option "pgbouncer"`

## Change
- Update `services/ml/src/data/db.py` `_get_db_url()` to parse and strip the `pgbouncer` query param before returning the URL.
- Preserve other query params.

## Why this is safe
- Only affects URL normalization for ML DB connections.
- Leaves existing environment-variable behavior intact.
- Does not change SQL/query logic, only connection string cleanup.

## Validation
- Commit cherry-picked cleanly onto latest `main` (which already contains #228).
- Branch: `fix/ml-strip-pgbouncer-dsn`