### PR TITLE
fix(ml): prefer DIRECT_URL and strip connection_limit from DATABASE_URL

### DIFF
--- a/services/ml/src/data/db.py
+++ b/services/ml/src/data/db.py
@@ -39,14 +39,19 @@ __all__ = [
 
 
 def _get_db_url() -> str:
-    """Return the database URL, stripped of PgBouncer-specific options psycopg2 rejects."""
-    url = os.environ.get("DATABASE_URL", DATABASE_URL)
+    """Return a DB URL compatible with psycopg2/SQLAlchemy on Fly/Neon."""
+    # Prefer DIRECT_URL when present because it omits pooled-only query params.
+    url = os.environ.get("DIRECT_URL") or os.environ.get("DATABASE_URL", DATABASE_URL)
     if not url:
-        raise RuntimeError("DATABASE_URL environment variable is required but not set.")
-    # Neon pooled URLs include ?pgbouncer=true which psycopg2 doesn't understand.
+        raise RuntimeError(
+            "DATABASE_URL environment variable is required but not set."
+        )
+    # Neon pooled URLs can include options psycopg2 rejects.
+    # Keep other params (e.g. sslmode), but remove unsupported pool-only keys.
     parsed = urlparse(url)
     params = parse_qs(parsed.query, keep_blank_values=True)
     params.pop("pgbouncer", None)
+    params.pop("connection_limit", None)
     cleaned = parsed._replace(query=urlencode(params, doseq=True))
     return urlunparse(cleaned)
 


### PR DESCRIPTION
## Summary
Hardens ML DB URL resolution for Neon/Fly so cron jobs can always connect via psycopg2.

## Changes
- Prefer `DIRECT_URL` when present (direct Postgres endpoint, no pooled-only params).
- Fallback to `DATABASE_URL` when `DIRECT_URL` is absent.
- Sanitize unsupported pooled query parameters from URL before creating SQLAlchemy/psycopg2 connections:
  - `pgbouncer`
  - `connection_limit`
- Preserve other valid params (e.g. `sslmode`, `channel_binding`).

## Why
Production cron failed with:
- `invalid connection option "pgbouncer"`
- then `invalid connection option "connection_limit"`

This patch removes those failure modes while keeping TLS-related settings intact.