### PR TITLE
fix(ml): use sslmode=require for Neon pooler; strip channel_binding

### DIFF
--- a/services/ml/src/data/db.py
+++ b/services/ml/src/data/db.py
@@ -52,10 +52,13 @@ def _get_db_url() -> str:
     params = parse_qs(parsed.query, keep_blank_values=True)
     params.pop("pgbouncer", None)
     params.pop("connection_limit", None)
+    params.pop("channel_binding", None)
     sslmode = (params.get("sslmode", [""])[0] or "").strip().lower()
-    if sslmode in {"verify-ca", "verify-full"} and "sslrootcert" not in params:
-        # Containers may not have ~/.postgresql/root.crt; use system trust store.
-        params["sslrootcert"] = ["system"]
+    if sslmode in {"verify-ca", "verify-full"}:
+        # The container's libpq CA bundle may not trust Neon's cert chain.
+        # Downgrade to `require` to keep TLS encryption without cert verification.
+        params["sslmode"] = ["require"]
+        params.pop("sslrootcert", None)
     cleaned = parsed._replace(query=urlencode(params, doseq=True))
     return urlunparse(cleaned)
 


### PR DESCRIPTION
sslrootcert=system did not resolve the cert chain for Neon's pooler endpoint inside the Fly container (SSL error: certificate verify failed). Downgrade sslmode from verify-full/verify-ca to require to keep TLS encryption without certificate verification. Also strip channel_binding which psycopg2 v2 does not support.