### PR TITLE
fix(notifications): address PR #232 review feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
         run: pnpm typecheck
 
       - name: Run unit tests
+        timeout-minutes: 15
         run: pnpm test -- --coverage
 
       - name: Backend E2E tests

--- a/.github/workflows/mobile-test-hygiene.yml
+++ b/.github/workflows/mobile-test-hygiene.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  pull_request:
   schedule:
     # 11:00 UTC daily
     - cron: '0 11 * * *'

--- a/apps/backend/src/notifications/notifications.controller.spec.ts
+++ b/apps/backend/src/notifications/notifications.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { NotificationsController } from './notifications.controller';
 import { NotificationsService } from './notifications.service';
 import { DebugPushType, DebugSendPushDto } from './dto/debug-send-push.dto';
@@ -12,26 +13,28 @@ const mockNotificationsService = {
   debugPushTestByEmail: jest.fn(),
 };
 
+const mockConfigService = {
+  get: jest.fn(),
+};
+
 describe('NotificationsController', () => {
   let controller: NotificationsController;
-  const originalNodeEnv = process.env.NODE_ENV;
-  const originalDebugPushFlag = process.env.ENABLE_DEBUG_PUSH_TEST;
 
   beforeEach(async () => {
+    mockConfigService.get.mockReset();
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [NotificationsController],
-      providers: [{ provide: NotificationsService, useValue: mockNotificationsService }],
+      providers: [
+        { provide: NotificationsService, useValue: mockNotificationsService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
     }).compile();
 
     controller = module.get(NotificationsController);
   });
 
   afterEach(() => jest.clearAllMocks());
-
-  afterAll(() => {
-    process.env.NODE_ENV = originalNodeEnv;
-    process.env.ENABLE_DEBUG_PUSH_TEST = originalDebugPushFlag;
-  });
 
   describe('POST me/push-token', () => {
     const dto: RegisterPushTokenDto = { token: 'fcm-abc123', platform: 'ios' };
@@ -90,8 +93,11 @@ describe('NotificationsController', () => {
     const dto: DebugSendPushDto = { type: DebugPushType.SURGE, lotId: 'G1' };
 
     it('throws ForbiddenException in production even when flag is true', async () => {
-      process.env.NODE_ENV = 'production';
-      process.env.ENABLE_DEBUG_PUSH_TEST = 'true';
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'NODE_ENV') return 'production';
+        if (key === 'ENABLE_DEBUG_PUSH_TEST') return 'true';
+        return undefined;
+      });
       const req = { user: { email: 'student@csulb.edu' } } as any;
 
       await expect(controller.sendPushTest(req, dto)).rejects.toThrow(ForbiddenException);
@@ -99,8 +105,11 @@ describe('NotificationsController', () => {
     });
 
     it('throws ForbiddenException when debug flag is not enabled', async () => {
-      process.env.NODE_ENV = 'development';
-      process.env.ENABLE_DEBUG_PUSH_TEST = 'false';
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'NODE_ENV') return 'development';
+        if (key === 'ENABLE_DEBUG_PUSH_TEST') return 'false';
+        return undefined;
+      });
       const req = { user: { email: 'student@csulb.edu' } } as any;
 
       await expect(controller.sendPushTest(req, dto)).rejects.toThrow(ForbiddenException);
@@ -108,8 +117,11 @@ describe('NotificationsController', () => {
     });
 
     it('throws UnauthorizedException when debug endpoint is enabled but email is missing', async () => {
-      process.env.NODE_ENV = 'development';
-      process.env.ENABLE_DEBUG_PUSH_TEST = 'true';
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'NODE_ENV') return 'development';
+        if (key === 'ENABLE_DEBUG_PUSH_TEST') return 'true';
+        return undefined;
+      });
       const req = { user: {} } as any;
 
       await expect(controller.sendPushTest(req, dto)).rejects.toThrow(UnauthorizedException);
@@ -117,8 +129,11 @@ describe('NotificationsController', () => {
     });
 
     it('delegates to debugPushTestByEmail when endpoint is enabled and email is present', async () => {
-      process.env.NODE_ENV = 'development';
-      process.env.ENABLE_DEBUG_PUSH_TEST = 'true';
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'NODE_ENV') return 'development';
+        if (key === 'ENABLE_DEBUG_PUSH_TEST') return 'true';
+        return undefined;
+      });
       const req = { user: { email: 'student@csulb.edu' } } as any;
       mockNotificationsService.debugPushTestByEmail.mockResolvedValue({
         sent: true,

--- a/apps/backend/src/notifications/notifications.controller.ts
+++ b/apps/backend/src/notifications/notifications.controller.ts
@@ -9,6 +9,7 @@ import {
   UnauthorizedException,
   ForbiddenException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
 import { NotificationsService } from './notifications.service';
 import { RegisterPushTokenDto } from './dto/register-push-token.dto';
@@ -21,7 +22,10 @@ interface AuthenticatedRequest extends Request {
 
 @Controller('users')
 export class NotificationsController {
-  constructor(private readonly notificationsService: NotificationsService) {}
+  constructor(
+    private readonly notificationsService: NotificationsService,
+    private readonly configService: ConfigService,
+  ) {}
 
   /**
    * Register/refresh a device push token for the authenticated user.
@@ -69,8 +73,9 @@ export class NotificationsController {
     @Req() req: AuthenticatedRequest,
     @Body() dto: DebugSendPushDto,
   ): Promise<{ sent: boolean; pushConfigured: boolean; tokenCount: number }> {
-    const debugPushEnabled = process.env.ENABLE_DEBUG_PUSH_TEST === 'true';
-    if (process.env.NODE_ENV === 'production' || !debugPushEnabled) {
+    const isProduction = this.configService.get<string>('NODE_ENV') === 'production';
+    const debugPushEnabled = this.configService.get<string>('ENABLE_DEBUG_PUSH_TEST') === 'true';
+    if (isProduction || !debugPushEnabled) {
       throw new ForbiddenException('Push test endpoint is disabled (set ENABLE_DEBUG_PUSH_TEST=true in non-production environments)');
     }
 

--- a/apps/backend/src/notifications/notifications.service.spec.ts
+++ b/apps/backend/src/notifications/notifications.service.spec.ts
@@ -367,6 +367,22 @@ describe('NotificationsService', () => {
         data: { type: 'events' },
       });
     });
+
+    it('maps surge payload without lotId', async () => {
+      mockApps.push({});
+      prisma.pushToken.count.mockResolvedValue(1);
+      const sendSpy = jest.spyOn(service, 'sendPush').mockResolvedValue(true);
+
+      await service.debugPushTestByEmail('student@csulb.edu', {
+        type: DebugPushType.SURGE,
+      });
+
+      expect(sendSpy).toHaveBeenCalledWith('user-cuid', {
+        title: 'Campus Surge Alert',
+        body: 'Multiple lots are over 90% full right now.',
+        data: { type: 'surge' },
+      });
+    });
   });
 
   // ─── hasRecentLog ──────────────────────────────────────────────────────

--- a/apps/backend/src/notifications/notifications.service.ts
+++ b/apps/backend/src/notifications/notifications.service.ts
@@ -57,16 +57,6 @@ export class NotificationsService implements OnModuleInit {
     await this.registerPushToken(user.id, token, platform);
   }
 
-  async sendDebugPushByEmail(email: string, dto: DebugSendPushDto): Promise<boolean> {
-    const user = await this.prisma.user.findUniqueOrThrow({
-      where: { email },
-      select: { id: true },
-    });
-
-    const payload = this.buildDebugPayload(dto);
-    return this.sendPush(user.id, payload);
-  }
-
   async debugPushTestByEmail(
     email: string,
     dto: DebugSendPushDto,
@@ -110,7 +100,7 @@ export class NotificationsService implements OnModuleInit {
         return {
           title: 'Campus Surge Alert',
           body: 'Multiple lots are over 90% full right now.',
-          data: { type: 'surge', lotId },
+          data: { type: 'surge' },
         };
       case DebugPushType.EVENTS:
         return {

--- a/apps/mobile/__tests__/App.test.tsx
+++ b/apps/mobile/__tests__/App.test.tsx
@@ -108,6 +108,14 @@ jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
+// Mock the min-version fetch so App.tsx doesn't hit the network during render.
+// Without this, the real apiService retries against ECONNREFUSED and the
+// late rejection bleeds past test teardown -> jest exit 1 under
+// --detectOpenHandles in the mobile-test-hygiene workflow.
+jest.mock('../src/services/api/version', () => ({
+  fetchMinVersion: jest.fn().mockResolvedValue({ minSupportedVersion: '0.0.0' }),
+}));
+
 // Mock EnhancedGeofencingProvider — the provider App.tsx actually mounts
 jest.mock('../src/context/EnhancedGeofencingProvider', () => ({
   EnhancedGeofencingProvider: ({ children }: { children: React.ReactNode }) => children,

--- a/apps/mobile/__tests__/EnhancedGeofencingProvider.test.tsx
+++ b/apps/mobile/__tests__/EnhancedGeofencingProvider.test.tsx
@@ -178,9 +178,11 @@ async function flushEffects(): Promise<void> {
 }
 
 async function waitForProviderReady(): Promise<void> {
-  for (let i = 0; i < 6; i += 1) {
+  for (let i = 0; i < 20; i += 1) {
     await flushEffects();
+    if (mockLotsApi.getAllLots.mock.calls.length > 0) return;
   }
+  throw new Error('waitForProviderReady: provider did not complete initialization');
 }
 
 async function emitGeofence(event: GeofenceEvent): Promise<void> {


### PR DESCRIPTION
Follow-up to #232 (merged before review nits could land). Addresses Zach Padilla's review comments:

- **notifications.controller**: inject `ConfigService` instead of reading `process.env` directly
- **notifications.service**: remove unused `sendDebugPushByEmail`; drop `lotId` from SURGE payload (campus-wide, matches `notify-surge.job` producer)
- **specs**: `ConfigService` mock replaces env mutation; assert SURGE payload has no `lotId`
- **ci.yml**: add `timeout-minutes: 15` to unit tests step
- **mobile-test-hygiene.yml**: add `pull_request` trigger so the job runs on PRs
- **EnhancedGeofencingProvider.test**: `waitForProviderReady` now polls a deterministic init signal (`mockLotsApi.getAllLots` call count) instead of fixed timer advancement

## Validation
- ✅ Backend unit tests (44/44 in notifications specs)
- ✅ Backend typecheck clean (build + scripts)
- ✅ Mobile `EnhancedGeofencingProvider` tests (4/4)
- ✅ Mobile typecheck clean
- ✅ Repo-wide lint + typecheck via turbo (5/5 packages)

Refs #232