### PR TITLE
fix(android): lot, logout, and geofence init fixes

### DIFF
--- a/apps/mobile/src/auth/AzureAuth.tsx
+++ b/apps/mobile/src/auth/AzureAuth.tsx
@@ -214,19 +214,19 @@ export const logoutFromAzure = async (idToken?: string): Promise<void> => {
       log('[AzureAuth] Azure AD logout successful');
     } catch (logoutError) {
       const errorMessage = (logoutError as Error).message || '';
-      
-      // Check if user explicitly cancelled the logout
-      if (errorMessage.includes('User cancelled') || errorMessage.includes('cancel')) {
-        log('[AzureAuth] User cancelled logout');
-        userCancelled = true;
+
+      if (Platform.OS === 'android') {
+        // Android Chrome Custom Tabs always throws on end-session (even on success);
+        // the server-side session is still invalidated — continue to clear local state.
+        log('[AzureAuth] Android logout error (continuing with local cleanup):', errorMessage);
       } else if (errorMessage.includes('error -3') || errorMessage.includes('org.openid.appauth.general')) {
         // AppAuth error -3 (OIDErrorCodeUserCanceledAuthorizationFlow) is expected with Azure AD
         // on iOS. The logout endpoint clears the session but doesn't redirect back properly.
         log('[AzureAuth] Azure AD session cleared (browser dismissed - this is expected)');
-      } else if (Platform.OS === 'android') {
-        // Android Chrome Custom Tabs may throw on end-session; the server-side
-        // session is still invalidated — continue to clear local state.
-        log('[AzureAuth] Android logout error (continuing with local cleanup):', errorMessage);
+      } else if (errorMessage.includes('User cancelled') || errorMessage.includes('cancel')) {
+        // iOS only: user explicitly dismissed the browser before completing logout
+        log('[AzureAuth] User cancelled logout');
+        userCancelled = true;
       } else {
         if (__DEV__) {
           console.warn('[AzureAuth] Azure AD logout encountered an issue, clearing local state:', logoutError);

--- a/apps/mobile/src/constants/theme.ts
+++ b/apps/mobile/src/constants/theme.ts
@@ -73,8 +73,8 @@ export const TYPOGRAPHY = {
     bold: 'Inter-Bold',
   },
   fontSize: {
+    xxxs: 8,
     xxs: 9,
-    xxs2: 11,
     xs: 10,
     sm: 12,
     md: 14,

--- a/apps/mobile/src/screens/MapScreen.tsx
+++ b/apps/mobile/src/screens/MapScreen.tsx
@@ -908,7 +908,7 @@ const styles = StyleSheet.create({
     borderWidth: 1.5,
     alignItems: 'center',
     justifyContent: 'center',
-    maxWidth: 40,
+    maxWidth: 56,
   },
   lotCircle: {
     width: 40,

--- a/apps/mobile/src/screens/MapScreen.tsx
+++ b/apps/mobile/src/screens/MapScreen.tsx
@@ -38,40 +38,20 @@ import { LOT_POLYGONS } from '../data/lotPolygons'
 import { isPointInsidePolygon, polygonCentroid } from '../utils/lotGeometry';
 
 const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
-// const CAMPUS_REGION = {
-//   latitude: 33.78195,
-//   longitude: -118.11486,
-//   latitudeDelta: 0.018,
-//   longitudeDelta: 0.018,
-// };
-// const CAMPUS_RECENTER_THRESHOLD_METERS = 1200;
-// const CAMPUS_VISUAL_CENTER_BIAS = 0.2;
-// const CAMPUS_VISUAL_HORIZONTAL_BIAS = 0.2;
-// const CAMPUS_EDGE_PADDING_TOP = 64;
-// const CAMPUS_EDGE_PADDING_TOP_WITH_PARKED = 100;
-// const CAMPUS_EDGE_PADDING_RIGHT = 50;
-// const CAMPUS_EDGE_PADDING_LEFT = 36;
-// const CAMPUS_EDGE_PADDING_BOTTOM_BASE = 290;
-
-function centroid(ring: LatLng[]): { latitude: number; longitude: number } {
-  const pts =
-    ring.length > 1 &&
-    ring[0].lat === ring[ring.length - 1].lat &&
-    ring[0].lng === ring[ring.length - 1].lng
-      ? ring.slice(0, -1)
-      : ring;
-  const n = pts.length;
-  let area = 0, lat = 0, lng = 0;
-  for (let i = 0; i < n; i++) {
-    const j = (i + 1) % n;
-    const cross = pts[i].lat * pts[j].lng - pts[j].lat * pts[i].lng;
-    area += cross;
-    lat  += (pts[i].lat + pts[j].lat) * cross;
-    lng  += (pts[i].lng + pts[j].lng) * cross;
-  }
-  area /= 2;
-  return { latitude: lat / (6 * area), longitude: lng / (6 * area) };
-}
+const CAMPUS_REGION = {
+  latitude: 33.78195,
+  longitude: -118.11486,
+  latitudeDelta: 0.018,
+  longitudeDelta: 0.018,
+};
+const CAMPUS_RECENTER_THRESHOLD_METERS = 1200;
+const CAMPUS_VISUAL_CENTER_BIAS = 0.2;
+const CAMPUS_VISUAL_HORIZONTAL_BIAS = 0.2;
+const CAMPUS_EDGE_PADDING_TOP = 64;
+const CAMPUS_EDGE_PADDING_TOP_WITH_PARKED = 100;
+const CAMPUS_EDGE_PADDING_RIGHT = 50;
+const CAMPUS_EDGE_PADDING_LEFT = 36;
+const CAMPUS_EDGE_PADDING_BOTTOM_BASE = 290;
 
 function hexWithAlpha(hex: string, alpha: number): string {
   const clean = hex.startsWith('#') ? hex : `#${hex}`;
@@ -110,15 +90,13 @@ const InteractiveLot: React.FC<{
   // to dark text against light pin colors so the lot label stays legible
   // at every band. Redacted pins keep white over the neutral fill.
   const labelColor = isRedacted ? colors.white : getReadableTextColor(occupancyColor);
-  // const parkedLabelColor = colors.white;
-  // const isSingleWord = !lot.lot_name.trim().includes(' ');
-  // adjustsFontSizeToFit is broken in Android map markers (bitmap rendering
-  // skips multi-pass layout), so manually pick a size based on the longest word.
+  const parkedLabelColor = colors.white;
+  // adjustsFontSizeToFit is broken in Android map markers (bitmap rendering skips multi-pass layout)
   const androidFontSize = Platform.OS === 'android' ? (() => {
     const len = lot.lot_name.trim().length;
-    if (len <= 12)  return TYPOGRAPHY.fontSize.sm;   // 12px
-    if (len <= 16) return TYPOGRAPHY.fontSize.xs;   // 10px
-    return TYPOGRAPHY.fontSize.xxs;                  // 9px
+    if (len <= 12)  return TYPOGRAPHY.fontSize.xs;
+    if (len <= 16) return TYPOGRAPHY.fontSize.xxs;
+    return TYPOGRAPHY.fontSize.xxxs;
   })() : undefined;
 
   const a11yLabel = isRedacted
@@ -160,12 +138,13 @@ const InteractiveLot: React.FC<{
             ]}
           >
             <Text
-              // style={[styles.lotText, { color: isParkedLot ? parkedLabelColor : labelColor }]}
-              // numberOfLines={isSingleWord ? 1 : 2}
-              // ellipsizeMode="tail"
-              style={[styles.lotText, { color: colors.white }, androidFontSize != null && { fontSize: androidFontSize }]}
+              style={[
+                styles.lotText,
+                { color: isParkedLot ? parkedLabelColor : labelColor },
+                androidFontSize != null && { fontSize: androidFontSize }
+              ]}
+              ellipsizeMode="tail"
               adjustsFontSizeToFit={Platform.OS === 'ios'}
-              // minimumFontScale={0.75}
               allowFontScaling={Platform.OS === 'ios'}
               numberOfLines={3}
               accessible={false}
@@ -200,12 +179,13 @@ const InteractiveLot: React.FC<{
         accessible={false}
       >
         <Text
-          // style={[styles.lotText, { color: isParkedLot ? parkedLabelColor : labelColor }]}
-          // numberOfLines={isSingleWord ? 1 : 3}
-          // ellipsizeMode="tail"
-          style={[styles.lotText, { color: labelColor }, androidFontSize != null && { fontSize: androidFontSize }]}
+          style={[
+            styles.lotText,
+            { color: isParkedLot ? parkedLabelColor : labelColor },
+            androidFontSize != null && { fontSize: androidFontSize }
+          ]}
+          ellipsizeMode="tail"
           adjustsFontSizeToFit={Platform.OS === 'ios'}
-          // minimumFontScale={0.75}
           allowFontScaling={Platform.OS === 'ios'}
           numberOfLines={3}
           accessible={false}

--- a/apps/mobile/src/screens/MapScreen.tsx
+++ b/apps/mobile/src/screens/MapScreen.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   Dimensions,
   TouchableOpacity,
+  Platform,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Text } from '../components/CustomText';
@@ -37,20 +38,40 @@ import { LOT_POLYGONS } from '../data/lotPolygons'
 import { isPointInsidePolygon, polygonCentroid } from '../utils/lotGeometry';
 
 const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
-const CAMPUS_REGION = {
-  latitude: 33.78195,
-  longitude: -118.11486,
-  latitudeDelta: 0.018,
-  longitudeDelta: 0.018,
-};
-const CAMPUS_RECENTER_THRESHOLD_METERS = 1200;
-const CAMPUS_VISUAL_CENTER_BIAS = 0.2;
-const CAMPUS_VISUAL_HORIZONTAL_BIAS = 0.2;
-const CAMPUS_EDGE_PADDING_TOP = 64;
-const CAMPUS_EDGE_PADDING_TOP_WITH_PARKED = 100;
-const CAMPUS_EDGE_PADDING_RIGHT = 50;
-const CAMPUS_EDGE_PADDING_LEFT = 36;
-const CAMPUS_EDGE_PADDING_BOTTOM_BASE = 290;
+// const CAMPUS_REGION = {
+//   latitude: 33.78195,
+//   longitude: -118.11486,
+//   latitudeDelta: 0.018,
+//   longitudeDelta: 0.018,
+// };
+// const CAMPUS_RECENTER_THRESHOLD_METERS = 1200;
+// const CAMPUS_VISUAL_CENTER_BIAS = 0.2;
+// const CAMPUS_VISUAL_HORIZONTAL_BIAS = 0.2;
+// const CAMPUS_EDGE_PADDING_TOP = 64;
+// const CAMPUS_EDGE_PADDING_TOP_WITH_PARKED = 100;
+// const CAMPUS_EDGE_PADDING_RIGHT = 50;
+// const CAMPUS_EDGE_PADDING_LEFT = 36;
+// const CAMPUS_EDGE_PADDING_BOTTOM_BASE = 290;
+
+function centroid(ring: LatLng[]): { latitude: number; longitude: number } {
+  const pts =
+    ring.length > 1 &&
+    ring[0].lat === ring[ring.length - 1].lat &&
+    ring[0].lng === ring[ring.length - 1].lng
+      ? ring.slice(0, -1)
+      : ring;
+  const n = pts.length;
+  let area = 0, lat = 0, lng = 0;
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    const cross = pts[i].lat * pts[j].lng - pts[j].lat * pts[i].lng;
+    area += cross;
+    lat  += (pts[i].lat + pts[j].lat) * cross;
+    lng  += (pts[i].lng + pts[j].lng) * cross;
+  }
+  area /= 2;
+  return { latitude: lat / (6 * area), longitude: lng / (6 * area) };
+}
 
 function hexWithAlpha(hex: string, alpha: number): string {
   const clean = hex.startsWith('#') ? hex : `#${hex}`;
@@ -89,8 +110,17 @@ const InteractiveLot: React.FC<{
   // to dark text against light pin colors so the lot label stays legible
   // at every band. Redacted pins keep white over the neutral fill.
   const labelColor = isRedacted ? colors.white : getReadableTextColor(occupancyColor);
-  const parkedLabelColor = colors.white;
-  const isSingleWord = !lot.lot_name.trim().includes(' ');
+  // const parkedLabelColor = colors.white;
+  // const isSingleWord = !lot.lot_name.trim().includes(' ');
+  // adjustsFontSizeToFit is broken in Android map markers (bitmap rendering
+  // skips multi-pass layout), so manually pick a size based on the longest word.
+  const androidFontSize = Platform.OS === 'android' ? (() => {
+    const len = lot.lot_name.trim().length;
+    if (len <= 12)  return TYPOGRAPHY.fontSize.sm;   // 12px
+    if (len <= 16) return TYPOGRAPHY.fontSize.xs;   // 10px
+    return TYPOGRAPHY.fontSize.xxs;                  // 9px
+  })() : undefined;
+
   const a11yLabel = isRedacted
     ? `${lot.lot_name} parking lot, live occupancy locked. Grant background location to see live data.`
     : `${lot.lot_name} parking lot, ${pct} percent full`;
@@ -130,9 +160,14 @@ const InteractiveLot: React.FC<{
             ]}
           >
             <Text
-              style={[styles.lotText, { color: isParkedLot ? parkedLabelColor : labelColor }]}
-              numberOfLines={isSingleWord ? 1 : 2}
-              ellipsizeMode="tail"
+              // style={[styles.lotText, { color: isParkedLot ? parkedLabelColor : labelColor }]}
+              // numberOfLines={isSingleWord ? 1 : 2}
+              // ellipsizeMode="tail"
+              style={[styles.lotText, { color: colors.white }, androidFontSize != null && { fontSize: androidFontSize }]}
+              adjustsFontSizeToFit={Platform.OS === 'ios'}
+              // minimumFontScale={0.75}
+              allowFontScaling={Platform.OS === 'ios'}
+              numberOfLines={3}
               accessible={false}
             >
               {lot.lot_name}
@@ -165,9 +200,14 @@ const InteractiveLot: React.FC<{
         accessible={false}
       >
         <Text
-          style={[styles.lotText, { color: isParkedLot ? parkedLabelColor : labelColor }]}
-          numberOfLines={isSingleWord ? 1 : 3}
-          ellipsizeMode="tail"
+          // style={[styles.lotText, { color: isParkedLot ? parkedLabelColor : labelColor }]}
+          // numberOfLines={isSingleWord ? 1 : 3}
+          // ellipsizeMode="tail"
+          style={[styles.lotText, { color: labelColor }, androidFontSize != null && { fontSize: androidFontSize }]}
+          adjustsFontSizeToFit={Platform.OS === 'ios'}
+          // minimumFontScale={0.75}
+          allowFontScaling={Platform.OS === 'ios'}
+          numberOfLines={3}
           accessible={false}
         >
           {lot.lot_name}
@@ -888,7 +928,8 @@ const styles = StyleSheet.create({
     borderWidth: 1.5,
     alignItems: 'center',
     justifyContent: 'center',
-    maxWidth: 72,
+    // maxWidth: 72,
+    maxWidth: 40,
   },
   lotCircle: {
     width: 40,
@@ -909,6 +950,8 @@ const styles = StyleSheet.create({
     fontSize: TYPOGRAPHY.fontSize.xs,
     fontFamily: TYPOGRAPHY.fontFamily.bold,
     textAlign: 'center',
+    textAlignVertical: 'center',
+    includeFontPadding: false,
   },
   parkedCarMarkerOuter: {
     width: 28,

--- a/apps/mobile/src/screens/MapScreen.tsx
+++ b/apps/mobile/src/screens/MapScreen.tsx
@@ -908,7 +908,6 @@ const styles = StyleSheet.create({
     borderWidth: 1.5,
     alignItems: 'center',
     justifyContent: 'center',
-    // maxWidth: 72,
     maxWidth: 40,
   },
   lotCircle: {

--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -27,7 +27,7 @@ import { simulateForegroundPushMessage } from '../services/pushNotifications';
 import { sendDebugPushNotification } from '../services/api/notifications';
 
 const ProfileScreen: React.FC = () => {
-  const { themeMode, setThemeMode, colors } = useTheme();
+  const { themeMode, setThemeMode, colors, isDark } = useTheme();
 
   // Notification preferences — keys match the backend DTO.
   const [notifPrefs, setNotifPrefs] = useState<NotificationPreferences>({
@@ -462,9 +462,13 @@ const ProfileScreen: React.FC = () => {
                   </Text>
                 </View>
                 <View style={styles.statusBadge}>
-                <Text style={[styles.statusBadgeText, { 
-                        color: isGeofencingActive ? '#10b981' : colors.gray,
-                  backgroundColor: isGeofencingActive ? '#ecfdf5' : colors.lightGray,
+                <Text style={[styles.statusBadgeText, {
+                  color: isGeofencingActive
+                    ? (isDark ? '#6ee7b7' : '#10b981')
+                    : colors.gray,
+                  backgroundColor: isGeofencingActive
+                    ? (isDark ? 'rgba(16, 185, 129, 0.18)' : '#ecfdf5')
+                    : colors.lightGray,
                 }]}>
                     {getGeofencingStatusText()}
                   </Text>
@@ -501,8 +505,11 @@ const ProfileScreen: React.FC = () => {
               </TouchableOpacity>
 
               {currentLotId && (
-              <View style={[styles.statusInfo, { backgroundColor: '#ecfdf5', borderColor: '#10b981' }]}>
-                <Text style={[styles.statusText, { color: '#059669' }]}>
+              <View style={[styles.statusInfo, {
+                backgroundColor: isDark ? 'rgba(16, 185, 129, 0.18)' : '#ecfdf5',
+                borderColor: isDark ? 'rgba(16, 185, 129, 0.4)' : '#10b981',
+              }]}>
+                <Text style={[styles.statusText, { color: isDark ? '#6ee7b7' : '#059669' }]}>
                   📍 Currently in parking lot
                 </Text>
               </View>

--- a/apps/mobile/src/services/locationService.ts
+++ b/apps/mobile/src/services/locationService.ts
@@ -109,6 +109,19 @@ class LocationService {
    * No active GPS tracking — only OS-level geofence ENTER/EXIT/DWELL events fire.
    */
   async startGeofenceMonitoring(): Promise<State> {
+    // On Android with startOnBoot:true the SDK auto-restores its running state
+    // before JS fires, so calling startGeofences() while it's already enabled
+    // throws "Waiting for previous start action to complete". Skip the call if
+    // the SDK reports it's already running.
+    const currentState = await BackgroundGeolocation.getState();
+    if (currentState.enabled) {
+      this.trackingMode = 'geofences';
+      if (__DEV__) {
+        console.log('[LocationService] SDK already running, skipping startGeofences()');
+      }
+      return currentState;
+    }
+
     const state = await BackgroundGeolocation.startGeofences();
     this.trackingMode = 'geofences';
 


### PR DESCRIPTION
# Android: Lot Label, Logout, & Geofence Init Fixes

## Summary

Resolves several Android-specific bugs: lot labels were rendering strangely (very small text), a logout flow that misread a Chrome Custom Tab dismissal as user cancellation, a geolocation SDK re-init crash on app startup, and a clipped lot label caused by a `maxWidth`/`minWidth` conflict. Also fixes the geofencing status badge in ProfileScreen, which used hardcoded light-mode green values that clashed with the dark card surface.

## Changes

**`AzureAuth.tsx`** — Fixed Android logout being incorrectly treated as user cancellation. Chrome Custom Tabs always throws on end-session (even after a successful logout), so the Android branch is now evaluated first, before the generic "cancel" string check that was intercepting it.

**`locationService.ts`** — Fixed `"Waiting for previous start action to complete"` crash on app init. With `startOnBoot: true` and `stopOnTerminate: false`, the Background Geolocation SDK auto-restores its running state on Android before the JS side fires. `startGeofenceMonitoring()` now reads `getState()` first and skips `startGeofences()` if the SDK is already enabled.

**`MapScreen.tsx`** — Fixed lot label text from rendering too small regardless of component attributes due to bitmap rendering on Android skipping multi-pass layouts. For Android, `adjustsFontSizeToFit` is replaced with a custom `androidFontSize` selection.

**`ProfileScreen.tsx`** — Fixed geofencing status badge and "Currently in parking lot" info strip rendering with harsh light-green pastel backgrounds in dark mode. Both now use the same `rgba` tint + brighter foreground pattern already established by the advisory palette in `LotAmenities`.

**`theme.ts`** — Renamed `xxs2` → `xxxs` and added a true `xxxs` (8px) size to complete the font scale used by the Android lot label sizing logic.

## Screenshots

| iOS MapScreen | Android MapScreen |
|:-:|:-:|
| <img width="201" height="447" alt="Screenshot 2026-05-10 at 7 47 59 PM" src="https://github.com/user-attachments/assets/11e7a34c-1c0e-491c-8cd8-49c1046bb2fe" /> | <img width="201" height="447" alt="image" src="https://github.com/user-attachments/assets/14c502a6-da63-43d3-b456-5c6658d509a3" /> |